### PR TITLE
Added the unbreakable flag to the item creation

### DIFF
--- a/src/me/rockyhawk/commandpanels/classresources/ItemCreation.java
+++ b/src/me/rockyhawk/commandpanels/classresources/ItemCreation.java
@@ -373,6 +373,16 @@ public class ItemCreation {
                     }
                 }
             }
+
+            if (itemSection.contains("unbreakable")) {
+                // Applies the unbreakable flag to the item. Only works in non legacy versions
+                if (itemSection.getBoolean("unbreakable") == true && plugin.legacy.LOCAL_VERSION.lessThanOrEqualTo(MinecraftVersions.v1_12)){
+                    ItemMeta unbreak = s.getItemMeta();
+                    unbreak.setUnbreakable(true);
+                    s.setItemMeta(unbreak);
+                }
+            }
+
             if (itemSection.contains("nbt")) {
                 for(String key : itemSection.getConfigurationSection("nbt").getKeys(false)){
                     s = plugin.nbt.setNBT(s,key,itemSection.getString("nbt." + key));


### PR DESCRIPTION
This commit adds the possibility for server owners to apply the unbreakable flag to items, this is often used in 1.14- versions to apply custom textures to items. These textures are applied by having an unbreakable damaged item.