### PR TITLE
Added MiniMessage Support as CommandTag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,5 +12,19 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
     </properties>
-    
+
+    <repositories>
+        <repository>
+            <id>sonatype</id>
+            <url>https://oss.sonatype.org/content/groups/public/</url>
+        </repository>
+    </repositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.kyori</groupId>
+            <artifactId>adventure-text-minimessage</artifactId>
+            <version>4.11.0</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/src/me/rockyhawk/commandpanels/classresources/Serializer.java
+++ b/src/me/rockyhawk/commandpanels/classresources/Serializer.java
@@ -1,0 +1,12 @@
+package me.rockyhawk.commandpanels.classresources;
+
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+
+public class Serializer {
+
+    public static Component serializeText(String msg){
+        Component parsedText = MiniMessage.miniMessage().deserialize(msg);
+        return parsedText;
+    }
+}

--- a/src/me/rockyhawk/commandpanels/classresources/SerializerUtils.java
+++ b/src/me/rockyhawk/commandpanels/classresources/SerializerUtils.java
@@ -3,7 +3,7 @@ package me.rockyhawk.commandpanels.classresources;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 
-public class Serializer {
+public class SerializerUtils {
 
     public static Component serializeText(String msg){
         Component parsedText = MiniMessage.miniMessage().deserialize(msg);

--- a/src/me/rockyhawk/commandpanels/commandtags/tags/standard/BasicTags.java
+++ b/src/me/rockyhawk/commandpanels/commandtags/tags/standard/BasicTags.java
@@ -2,12 +2,20 @@ package me.rockyhawk.commandpanels.commandtags.tags.standard;
 
 import me.rockyhawk.commandpanels.CommandPanels;
 import me.rockyhawk.commandpanels.api.PanelCommandEvent;
+import me.rockyhawk.commandpanels.classresources.Serializer;
 import me.rockyhawk.commandpanels.commandtags.CommandTagEvent;
+import me.rockyhawk.commandpanels.ioclasses.legacy.LegacyVersion;
+import me.rockyhawk.commandpanels.ioclasses.legacy.MinecraftVersions;
 import me.rockyhawk.commandpanels.openpanelsmanager.PanelOpenType;
+import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.text.Component;
 import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
+
+import java.util.Arrays;
 
 public class BasicTags implements Listener {
     CommandPanels plugin;
@@ -97,6 +105,22 @@ public class BasicTags implements Listener {
             e.commandTagUsed();
             PanelCommandEvent commandEvent = new PanelCommandEvent(e.p, e.args[0], e.panel);
             Bukkit.getPluginManager().callEvent(commandEvent);
+        }
+        if(e.name.equalsIgnoreCase("minimessage=")){
+            e.commandTagUsed();
+            String tag = plugin.config.getString("config.format.tag") + " ";
+            if(Bukkit.getServer().getVersion().contains("Paper")){
+                LegacyVersion legacy = new LegacyVersion(plugin);
+                if(legacy.LOCAL_VERSION.greaterThanOrEqualTo(MinecraftVersions.v1_18)){
+                    Audience player = (Audience) e.p; // Needed because the basic Player from the Event can't send Paper's Components
+                    Component parsedText = Serializer.serializeText(String.join(" ",e.args));
+                    player.sendMessage(parsedText);
+                }else{
+                    plugin.tex.sendString(e.p, tag + ChatColor.RED + "MiniMessage-Feature needs Paper 1.18 or newer to work!");
+                }
+            }else{
+                plugin.tex.sendString(e.p, tag + ChatColor.RED + "MiniMessage-Feature needs Paper 1.18 or newer to work!");
+            }
         }
     }
 }

--- a/src/me/rockyhawk/commandpanels/commandtags/tags/standard/BasicTags.java
+++ b/src/me/rockyhawk/commandpanels/commandtags/tags/standard/BasicTags.java
@@ -2,7 +2,7 @@ package me.rockyhawk.commandpanels.commandtags.tags.standard;
 
 import me.rockyhawk.commandpanels.CommandPanels;
 import me.rockyhawk.commandpanels.api.PanelCommandEvent;
-import me.rockyhawk.commandpanels.classresources.Serializer;
+import me.rockyhawk.commandpanels.classresources.SerializerUtils;
 import me.rockyhawk.commandpanels.commandtags.CommandTagEvent;
 import me.rockyhawk.commandpanels.ioclasses.legacy.LegacyVersion;
 import me.rockyhawk.commandpanels.ioclasses.legacy.MinecraftVersions;
@@ -14,8 +14,6 @@ import org.bukkit.ChatColor;
 import org.bukkit.Sound;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-
-import java.util.Arrays;
 
 public class BasicTags implements Listener {
     CommandPanels plugin;
@@ -113,7 +111,7 @@ public class BasicTags implements Listener {
                 LegacyVersion legacy = new LegacyVersion(plugin);
                 if(legacy.LOCAL_VERSION.greaterThanOrEqualTo(MinecraftVersions.v1_18)){
                     Audience player = (Audience) e.p; // Needed because the basic Player from the Event can't send Paper's Components
-                    Component parsedText = Serializer.serializeText(String.join(" ",e.args));
+                    Component parsedText = SerializerUtils.serializeText(String.join(" ",e.args));
                     player.sendMessage(parsedText);
                 }else{
                     plugin.tex.sendString(e.p, tag + ChatColor.RED + "MiniMessage-Feature needs Paper 1.18 or newer to work!");


### PR DESCRIPTION
- CommandTags: minimessage=

Tested with: 1.19, 1.18, 1.16
**_DISCLAIMER:_** Only works on Paper 1.18 or newer! Other Plattforms or earlier versions can't use this CommandTag