### PR TITLE
Paywall-Message-Toggles | Remove Space after Tag | Use Tag provided by Main Class

### DIFF
--- a/resource/config.yml
+++ b/resource/config.yml
@@ -53,20 +53,26 @@ updater:
   update-checks: true
 purchase:
   currency:
+    enable: true
     success: '&aSuccessfully Bought For $%cp-args%'
     failure: '&cInsufficient Funds!'
   data:
+    enable: true
     success: '&aSuccessfully Bought For $%cp-args%'
     failure: '&cInsufficient Funds!'
   tokens:
+    enable: true
     success: '&aSuccessfully Bought For %cp-args% Tokens.'
     failure: '&cInsufficient Tokens!'
   coins:
+    enable: true
     success: '&aSuccessfully Bought For %cp-args% Coins.'
     failure: '&cInsufficient Coins!'
   item:
+    enable: true
     success: '&aSuccessfully Sold %cp-args%.'
     failure: '&cInsufficient Items!'
   xp:
+    enable: true
     success: '&aSuccessfully Bought For %cp-args% Experience.'
     failure: '&cInsufficient Experience!'

--- a/src/me/rockyhawk/commandpanels/CommandPanels.java
+++ b/src/me/rockyhawk/commandpanels/CommandPanels.java
@@ -276,7 +276,7 @@ public class CommandPanels extends JavaPlugin{
         }));
 
         //get tag
-        tag = tex.colour(config.getString("config.format.tag") + " ");
+        tag = tex.colour(config.getString("config.format.tag"));
 
         Bukkit.getLogger().info("[CommandPanels] RockyHawk's CommandPanels v" + this.getDescription().getVersion() + " Plugin Loaded!");
     }

--- a/src/me/rockyhawk/commandpanels/commands/Commandpanelsreload.java
+++ b/src/me/rockyhawk/commandpanels/commands/Commandpanelsreload.java
@@ -50,7 +50,6 @@ public class Commandpanelsreload implements CommandExecutor {
                     registerCommands();
                 }
 
-                plugin.tag = plugin.tex.colour(plugin.config.getString("config.format.tag"));
                 sender.sendMessage(plugin.tex.colour(plugin.tag + plugin.config.getString("config.format.reload")));
             }else{
                 sender.sendMessage(plugin.tex.colour(plugin.tag + plugin.config.getString("config.format.perms")));

--- a/src/me/rockyhawk/commandpanels/commands/Commandpanelsreload.java
+++ b/src/me/rockyhawk/commandpanels/commands/Commandpanelsreload.java
@@ -50,7 +50,7 @@ public class Commandpanelsreload implements CommandExecutor {
                     registerCommands();
                 }
 
-                plugin.tag = plugin.tex.colour(plugin.config.getString("config.format.tag") + " ");
+                plugin.tag = plugin.tex.colour(plugin.config.getString("config.format.tag"));
                 sender.sendMessage(plugin.tex.colour(plugin.tag + plugin.config.getString("config.format.reload")));
             }else{
                 sender.sendMessage(plugin.tex.colour(plugin.tag + plugin.config.getString("config.format.perms")));

--- a/src/me/rockyhawk/commandpanels/commandtags/CommandTags.java
+++ b/src/me/rockyhawk/commandpanels/commandtags/CommandTags.java
@@ -138,7 +138,7 @@ public class CommandTags {
 
     @SuppressWarnings("deprecation")
     public PaywallOutput commandPayWall(Panel panel, Player p, String rawCommand) { //return 0 means no funds, 1 is they passed and 2 means paywall is not this command
-        String tag = plugin.config.getString("config.format.tag") + " ";
+
         //create new instance of command but with placeholders parsed
         String command = plugin.tex.placeholders(panel,PanelPosition.Top,p,rawCommand);
         switch(command.split("\\s")[0]){
@@ -148,19 +148,23 @@ public class CommandTags {
                     if (plugin.econ != null) {
                         if (plugin.econ.getBalance(p) >= Double.parseDouble(command.split("\\s")[1])) {
                             plugin.econ.withdrawPlayer(p, Double.parseDouble(command.split("\\s")[1]));
-                            plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.currency.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
+                            if(plugin.config.getBoolean("purchase.currency.enable")){
+                                plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.currency.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
+                            }
                             return PaywallOutput.Passed;
                         } else {
-                            plugin.tex.sendString(p,plugin.config.getString("purchase.currency.failure"));
+                            if(plugin.config.getBoolean("purchase.currency.enable")){
+                                plugin.tex.sendString(p,plugin.config.getString("purchase.currency.failure"));
+                            }
                             return PaywallOutput.Blocked;
                         }
                     } else {
-                        plugin.tex.sendString(p, tag + ChatColor.RED + "Paying Requires Vault and an Economy to work!");
+                        plugin.tex.sendString(p, plugin.tag + ChatColor.RED + "Paying Requires Vault and an Economy to work!");
                         return PaywallOutput.Blocked;
                     }
                 } catch (Exception buyc) {
                     plugin.debug(buyc,p);
-                    plugin.tex.sendString(p, tag + plugin.config.getString("config.format.error") + " " + "commands: " + command);
+                    plugin.tex.sendString(p, plugin.tag + plugin.config.getString("config.format.error") + " " + "commands: " + command);
                     return PaywallOutput.Blocked;
                 }
             }
@@ -174,19 +178,24 @@ public class CommandTags {
                         if (balance >= Double.parseDouble(command.split("\\s")[1])) {
                             api.removeTokens(p, Long.parseLong(command.split("\\s")[1]));
                             //if the message is empty don't send
+                            if(plugin.config.getBoolean("purchase.tokens.enable")){
+                                plugin.tex.sendString(p,plugin.config.getString("purchase.tokens.failure"));
+                            }
                             plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.tokens.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
                             return PaywallOutput.Passed;
                         } else {
-                            plugin.tex.sendString(p,plugin.config.getString("purchase.tokens.failure"));
+                            if(plugin.config.getBoolean("purchase.tokens.enable")){
+                                plugin.tex.sendString(p,plugin.config.getString("purchase.tokens.failure"));
+                            }
                             return PaywallOutput.Blocked;
                         }
                     } else {
-                        plugin.tex.sendString(p, tag + ChatColor.RED + "Needs TokenManager to work!");
+                        plugin.tex.sendString(p, plugin.tag + ChatColor.RED + "Needs TokenManager to work!");
                         return PaywallOutput.Blocked;
                     }
                 } catch (Exception buyc) {
                     plugin.debug(buyc,p);
-                    plugin.tex.sendString(p, tag + plugin.config.getString("config.format.error") + " " + "commands: " + command);
+                    plugin.tex.sendString(p, plugin.tag + plugin.config.getString("config.format.error") + " " + "commands: " + command);
                     return PaywallOutput.Blocked;
                 }
             }
@@ -198,19 +207,23 @@ public class CommandTags {
                         if (balance >= Double.parseDouble(command.split("\\s")[1])) {
                             CoinsAPI.removeCoins(p.getUniqueId().toString(), (int) Long.parseLong(command.split("\\s")[1]));
                             //if the message is empty don't send
-                            plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.coins.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
+                            if(plugin.config.getBoolean("purchase.coins.enable")){
+                                plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.coins.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
+                            }
                             return PaywallOutput.Passed;
                         } else {
-                            plugin.tex.sendString(p,plugin.config.getString("purchase.coins.failure"));
+                            if(plugin.config.getBoolean("purchase.coins.enable")){
+                                plugin.tex.sendString(p,plugin.config.getString("purchase.coins.failure"));
+                            }
                             return PaywallOutput.Blocked;
                         }
                     } else {
-                        plugin.tex.sendString(p, tag + ChatColor.RED + "Needs CoinAPI to work!");
+                        plugin.tex.sendString(p, plugin.tag + ChatColor.RED + "Needs CoinAPI to work!");
                         return PaywallOutput.Blocked;
                     }
                 } catch (Exception buyc) {
                     plugin.debug(buyc,p);
-                    plugin.tex.sendString(p, tag + plugin.config.getString("config.format.error") + " " + "commands: " + command);
+                    plugin.tex.sendString(p, plugin.tag + plugin.config.getString("config.format.error") + " " + "commands: " + command);
                     return PaywallOutput.Blocked;
                 }
             }
@@ -301,14 +314,18 @@ public class CommandTags {
 
                     //send message and return
                     if(removedItem == PaywallOutput.Blocked){
-                        plugin.tex.sendString(p, tag + plugin.config.getString("purchase.item.failure"));
+                        if(plugin.config.getBoolean("purchase.item.enable")){
+                            plugin.tex.sendString(p, plugin.tag + plugin.config.getString("purchase.item.failure"));
+                        }
                     }else{
-                        plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.item.success")).replaceAll("%cp-args%",sellItem.getType().toString()));
+                        if(plugin.config.getBoolean("purchase.item.enable")){
+                            plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.item.success")).replaceAll("%cp-args%",sellItem.getType().toString()));
+                        }
                     }
                     return removedItem;
                 } catch (Exception buyc) {
                     plugin.debug(buyc,p);
-                    plugin.tex.sendString(p, tag + plugin.config.getString("config.format.error") + " " + "commands: " + command);
+                    plugin.tex.sendString(p, plugin.tag + plugin.config.getString("config.format.error") + " " + "commands: " + command);
                     return PaywallOutput.Blocked;
                 }
             }
@@ -328,15 +345,19 @@ public class CommandTags {
                             removePlayerExp(p,Integer.parseInt(command.split("\\s")[1]));
                         }
                         //if the message is empty don't send
-                        plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.xp.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
+                        if(plugin.config.getBoolean("purchase.xp.enable")){
+                            plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.xp.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
+                        }
                         return PaywallOutput.Passed;
                     } else {
-                        plugin.tex.sendString(p, plugin.config.getString("purchase.xp.failure"));
+                        if(plugin.config.getBoolean("purchase.xp.enable")){
+                            plugin.tex.sendString(p, plugin.config.getString("purchase.xp.failure"));
+                        }
                         return PaywallOutput.Blocked;
                     }
                 } catch (Exception buyc) {
                     plugin.debug(buyc,p);
-                    plugin.tex.sendString(p, tag + plugin.config.getString("config.format.error") + " " + "commands: " + command);
+                    plugin.tex.sendString(p, plugin.tag + plugin.config.getString("config.format.error") + " " + "commands: " + command);
                     return PaywallOutput.Blocked;
                 }
             }
@@ -346,15 +367,19 @@ public class CommandTags {
                     if (Double.parseDouble(plugin.panelData.getUserData(p.getUniqueId(),command.split("\\s")[1])) >= Double.parseDouble(command.split("\\s")[2])) {
                         plugin.panelData.doDataMath(p.getUniqueId(),command.split("\\s")[1],"-" + plugin.tex.placeholdersNoColour(panel,PanelPosition.Top,p,command.split("\\s")[2]));
                         //if the message is empty don't send
-                        plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.data.success")).replaceAll("%cp-args%", command.split("\\s")[2]));
+                        if(plugin.config.getBoolean("purchase.data.enable")){
+                            plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.data.success")).replaceAll("%cp-args%", command.split("\\s")[2]));
+                        }
                         return PaywallOutput.Passed;
                     } else {
-                        plugin.tex.sendString(p, plugin.config.getString("purchase.data.failure"));
+                        if(plugin.config.getBoolean("purchase.data.enable")){
+                            plugin.tex.sendString(p, plugin.config.getString("purchase.data.failure"));
+                        }
                         return PaywallOutput.Blocked;
                     }
                 } catch (Exception buyc) {
                     plugin.debug(buyc,p);
-                    plugin.tex.sendString(p, tag + plugin.config.getString("config.format.error") + " " + "commands: " + command);
+                    plugin.tex.sendString(p, plugin.tag + plugin.config.getString("config.format.error") + " " + "commands: " + command);
                     return PaywallOutput.Blocked;
                 }
             }


### PR DESCRIPTION
These Commits have the following changes:
- Add Toggles to all Purchase-Messages so that Players can disable those which they don't want.
- Remove the Space after the `format.tag`-Variable, so that Players don't have a space before their message if they remove the Text from the Tag
- Switched in some files from a "file-own" declaration of the `tag`-configvalue to the `plugin.tag`-variable defined by the `CommandPanels.java`-File