### PR TITLE
Add force-server= CommandTag

### DIFF
--- a/src/me/rockyhawk/commandpanels/commandtags/tags/standard/BungeeTags.java
+++ b/src/me/rockyhawk/commandpanels/commandtags/tags/standard/BungeeTags.java
@@ -17,7 +17,7 @@ public class BungeeTags implements Listener {
 
     @EventHandler
     public void commandTag(CommandTagEvent e){
-        if(e.name.equalsIgnoreCase("server=")){
+        if(e.name.equalsIgnoreCase("force-server=")){
             e.commandTagUsed();
             //this contacts bungee and tells it to send the server change command
             ByteArrayDataOutput out = ByteStreams.newDataOutput();
@@ -26,6 +26,19 @@ public class BungeeTags implements Listener {
             Player player = Bukkit.getPlayerExact(e.p.getName());
             assert player != null;
             player.sendPluginMessage(plugin, "BungeeCord", out.toByteArray());
+        } else if(e.name.equalsIgnoreCase("server=")){
+            e.commandTagUsed();
+            Player player = Bukkit.getPlayerExact(e.p.getName());
+            assert player != null;
+            if (player.hasPermission("bungeecord.command.server." + e.args[0].toLowerCase())) {
+                //this contacts bungee and tells it to send the server change command
+                ByteArrayDataOutput out = ByteStreams.newDataOutput();
+                out.writeUTF("Connect");
+                out.writeUTF(e.args[0]);
+                player.sendPluginMessage(plugin, "BungeeCord", out.toByteArray());
+            }else{
+                player.sendMessage(plugin.tex.colour(plugin.tag + plugin.config.getString("config.format.perms")));
+            }
         }
     }
 }


### PR DESCRIPTION
- Added `force-server=` Command Tag
- Changed the behavior of `server=` Command Tag 

**Changes to `server=` Command tag:**
It will now require the player to have the correct permission _(bungeecord.command.server.[server])_ to enter a restricted server.

**Behaviour of `force-server=` Command Tag:**
It behaves as `server=` does in previous versions of CP and sends the player to the desired server without any permission-checks

This PR was tested on **MC 1.19.2** with `Waterfall 1.19#504` and `Paper 1.19.2#135`.