### PR TITLE
Add PAPI and %cp-args%

### DIFF
--- a/src/me/rockyhawk/commandpanels/commandtags/CommandTags.java
+++ b/src/me/rockyhawk/commandpanels/commandtags/CommandTags.java
@@ -149,12 +149,12 @@ public class CommandTags {
                         if (plugin.econ.getBalance(p) >= Double.parseDouble(command.split("\\s")[1])) {
                             plugin.econ.withdrawPlayer(p, Double.parseDouble(command.split("\\s")[1]));
                             if(plugin.config.getBoolean("purchase.currency.enable")){
-                                plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.currency.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
+                                plugin.tex.sendString(panel, PanelPosition.Top, p, Objects.requireNonNull(plugin.config.getString("purchase.currency.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
                             }
                             return PaywallOutput.Passed;
                         } else {
                             if(plugin.config.getBoolean("purchase.currency.enable")){
-                                plugin.tex.sendString(p,plugin.config.getString("purchase.currency.failure"));
+                                plugin.tex.sendString(panel, PanelPosition.Top, p, Objects.requireNonNull(plugin.config.getString("purchase.currency.failure")).replaceAll("%cp-args%", command.split("\\s")[1]));
                             }
                             return PaywallOutput.Blocked;
                         }
@@ -179,13 +179,13 @@ public class CommandTags {
                             api.removeTokens(p, Long.parseLong(command.split("\\s")[1]));
                             //if the message is empty don't send
                             if(plugin.config.getBoolean("purchase.tokens.enable")){
-                                plugin.tex.sendString(p,plugin.config.getString("purchase.tokens.failure"));
+                                plugin.tex.sendString(panel, PanelPosition.Top, p, Objects.requireNonNull(plugin.config.getString("purchase.tokens.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
                             }
-                            plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.tokens.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
+                            plugin.tex.sendString(panel, PanelPosition.Top, p, Objects.requireNonNull(plugin.config.getString("purchase.tokens.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
                             return PaywallOutput.Passed;
                         } else {
                             if(plugin.config.getBoolean("purchase.tokens.enable")){
-                                plugin.tex.sendString(p,plugin.config.getString("purchase.tokens.failure"));
+                                plugin.tex.sendString(panel, PanelPosition.Top, p, Objects.requireNonNull(plugin.config.getString("purchase.tokens.failure")).replaceAll("%cp-args%", command.split("\\s")[1]));
                             }
                             return PaywallOutput.Blocked;
                         }
@@ -208,12 +208,12 @@ public class CommandTags {
                             CoinsAPI.removeCoins(p.getUniqueId().toString(), (int) Long.parseLong(command.split("\\s")[1]));
                             //if the message is empty don't send
                             if(plugin.config.getBoolean("purchase.coins.enable")){
-                                plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.coins.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
+                                plugin.tex.sendString(panel, PanelPosition.Top, p, Objects.requireNonNull(plugin.config.getString("purchase.coins.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
                             }
                             return PaywallOutput.Passed;
                         } else {
                             if(plugin.config.getBoolean("purchase.coins.enable")){
-                                plugin.tex.sendString(p,plugin.config.getString("purchase.coins.failure"));
+                                plugin.tex.sendString(panel, PanelPosition.Top, p, Objects.requireNonNull(plugin.config.getString("purchase.coins.failure")).replaceAll("%cp-args%", command.split("\\s")[1]));
                             }
                             return PaywallOutput.Blocked;
                         }
@@ -319,11 +319,11 @@ public class CommandTags {
                     //send message and return
                     if(removedItem == PaywallOutput.Blocked){
                         if(plugin.config.getBoolean("purchase.item.enable")){
-                            plugin.tex.sendString(p, plugin.tag + plugin.config.getString("purchase.item.failure"));
+                            plugin.tex.sendString(panel, PanelPosition.Top, p, Objects.requireNonNull(plugin.config.getString("purchase.item.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
                         }
                     }else{
                         if(plugin.config.getBoolean("purchase.item.enable")){
-                            plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.item.success")).replaceAll("%cp-args%",sellItem.getType().toString()));
+                            plugin.tex.sendString(panel, PanelPosition.Top, p, Objects.requireNonNull(plugin.config.getString("purchase.item.failure")).replaceAll("%cp-args%", command.split("\\s")[1]));
                         }
                     }
                     return removedItem;
@@ -350,12 +350,12 @@ public class CommandTags {
                         }
                         //if the message is empty don't send
                         if(plugin.config.getBoolean("purchase.xp.enable")){
-                            plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.xp.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
+                            plugin.tex.sendString(panel, PanelPosition.Top, p, Objects.requireNonNull(plugin.config.getString("purchase.xp.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
                         }
                         return PaywallOutput.Passed;
                     } else {
                         if(plugin.config.getBoolean("purchase.xp.enable")){
-                            plugin.tex.sendString(p, plugin.config.getString("purchase.xp.failure"));
+                            plugin.tex.sendString(panel, PanelPosition.Top, p, Objects.requireNonNull(plugin.config.getString("purchase.xp.failure")).replaceAll("%cp-args%", command.split("\\s")[1]));
                         }
                         return PaywallOutput.Blocked;
                     }
@@ -372,12 +372,12 @@ public class CommandTags {
                         plugin.panelData.doDataMath(p.getUniqueId(),command.split("\\s")[1],"-" + plugin.tex.placeholdersNoColour(panel,PanelPosition.Top,p,command.split("\\s")[2]));
                         //if the message is empty don't send
                         if(plugin.config.getBoolean("purchase.data.enable")){
-                            plugin.tex.sendString(p,Objects.requireNonNull(plugin.config.getString("purchase.data.success")).replaceAll("%cp-args%", command.split("\\s")[2]));
+                            plugin.tex.sendString(panel, PanelPosition.Top, p, Objects.requireNonNull(plugin.config.getString("purchase.data.success")).replaceAll("%cp-args%", command.split("\\s")[1]));
                         }
                         return PaywallOutput.Passed;
                     } else {
                         if(plugin.config.getBoolean("purchase.data.enable")){
-                            plugin.tex.sendString(p, plugin.config.getString("purchase.data.failure"));
+                            plugin.tex.sendString(panel, PanelPosition.Top, p, Objects.requireNonNull(plugin.config.getString("purchase.data.failure")).replaceAll("%cp-args%", command.split("\\s")[1]));
                         }
                         return PaywallOutput.Blocked;
                     }

--- a/src/me/rockyhawk/commandpanels/commandtags/tags/economy/BuyCommandTags.java
+++ b/src/me/rockyhawk/commandpanels/commandtags/tags/economy/BuyCommandTags.java
@@ -3,6 +3,7 @@ package me.rockyhawk.commandpanels.commandtags.tags.economy;
 import me.realized.tokenmanager.api.TokenManager;
 import me.rockyhawk.commandpanels.CommandPanels;
 import me.rockyhawk.commandpanels.commandtags.CommandTagEvent;
+import me.rockyhawk.commandpanels.openpanelsmanager.PanelPosition;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.event.EventHandler;
@@ -30,9 +31,10 @@ public class BuyCommandTags implements Listener {
                         String price = e.args[0];
                         String command = String.join(" ",Arrays.copyOfRange(e.raw, 1, e.raw.length));
                         plugin.commandTags.runCommand(e.panel,e.pos,e.p,command);
-                        plugin.tex.sendMessage(e.p,plugin.config.getString("purchase.currency.success").replaceAll("%cp-args%", price));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.currency.success")).replaceAll("%cp-args%", price));
                     } else {
-                        plugin.tex.sendMessage(e.p, plugin.config.getString("purchase.currency.failure"));
+                        String price = e.args[0];
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.currency.failure")).replaceAll("%cp-args%", price));
                     }
                 } else {
                     plugin.tex.sendMessage(e.p, ChatColor.RED + "Buying Requires Vault and an Economy to work!");
@@ -57,9 +59,10 @@ public class BuyCommandTags implements Listener {
                         String price = e.args[0];
                         String command = String.join(" ",Arrays.copyOfRange(e.raw, 1, e.raw.length));
                         plugin.commandTags.runCommand(e.panel,e.pos,e.p,command);
-                        plugin.tex.sendMessage(e.p, Objects.requireNonNull(plugin.config.getString("purchase.tokens.success")).replaceAll("%cp-args%", price));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.tokens.success")).replaceAll("%cp-args%", price));
                     } else {
-                        plugin.tex.sendMessage(e.p, plugin.config.getString("purchase.tokens.failure"));
+                        String price = e.args[0];
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.tokens.failure")).replaceAll("%cp-args%", price));
                     }
                 } else {
                     plugin.tex.sendMessage(e.p, ChatColor.RED + "Buying Requires Vault and an Economy to work!");

--- a/src/me/rockyhawk/commandpanels/commandtags/tags/economy/BuyItemTags.java
+++ b/src/me/rockyhawk/commandpanels/commandtags/tags/economy/BuyItemTags.java
@@ -5,6 +5,7 @@ import me.realized.tokenmanager.api.TokenManager;
 import me.rockyhawk.commandpanels.CommandPanels;
 import me.rockyhawk.commandpanels.commandtags.CommandTagEvent;
 import me.rockyhawk.commandpanels.ioclasses.legacy.MinecraftVersions;
+import me.rockyhawk.commandpanels.openpanelsmanager.PanelPosition;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -30,10 +31,11 @@ public class BuyItemTags implements Listener {
                 if (plugin.econ != null) {
                     if (plugin.econ.getBalance(e.p) >= Double.parseDouble(e.args[0])) {
                         plugin.econ.withdrawPlayer(e.p, Double.parseDouble(e.args[0]));
-                        plugin.tex.sendMessage(e.p, Objects.requireNonNull(plugin.config.getString("purchase.currency.success")).replaceAll("%cp-args%", e.args[0]));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.currency.success")).replaceAll("%cp-args%", e.args[0]));
                         giveItem(e.p, e.args);
                     } else {
-                        plugin.tex.sendMessage(e.p, plugin.config.getString("purchase.currency.failure"));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.currency.failure")).replaceAll("%cp-args%", e.args[0]));
+
                     }
                 } else {
                     plugin.tex.sendMessage(e.p, ChatColor.RED + "Buying Requires Vault and an Economy to work!");
@@ -55,9 +57,12 @@ public class BuyItemTags implements Listener {
                     if (balance >= Double.parseDouble(e.args[0])) {
                         api.removeTokens(e.p, Long.parseLong(e.args[0]));
                         plugin.tex.sendMessage(e.p, Objects.requireNonNull(plugin.config.getString("purchase.tokens.success")).replaceAll("%cp-args%", e.args[0]));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.tokens.success")).replaceAll("%cp-args%", e.args[0]));
+
                         giveItem(e.p,e.args);
                     } else {
-                        plugin.tex.sendMessage(e.p, plugin.config.getString("purchase.tokens.failure"));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.tokens.failure")).replaceAll("%cp-args%", e.args[0]));
+
                     }
                 } else {
                     plugin.tex.sendMessage(e.p, ChatColor.RED + "Buying Requires TokenManager to work!");
@@ -75,10 +80,10 @@ public class BuyItemTags implements Listener {
                     int balance = CoinsAPI.getCoins(e.p.getUniqueId().toString());
                     if (balance >= Double.parseDouble(e.args[0])) {
                         CoinsAPI.removeCoins(e.p.getUniqueId().toString(), (int) Long.parseLong(e.args[0]));
-                        plugin.tex.sendMessage(e.p, Objects.requireNonNull(plugin.config.getString("purchase.coins.success")).replaceAll("%cp-args%", e.args[0]));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.coins.success")).replaceAll("%cp-args%", e.args[0]));
                         giveItem(e.p,e.args);
                     } else {
-                        plugin.tex.sendMessage(e.p, plugin.config.getString("purchase.coins.failure"));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.coins.failure")).replaceAll("%cp-args%", e.args[0]));
                     }
                 } else {
                     plugin.tex.sendMessage(e.p, ChatColor.RED + "Buying Requires CoinsAPINB to work!");

--- a/src/me/rockyhawk/commandpanels/commandtags/tags/economy/SellItemTags.java
+++ b/src/me/rockyhawk/commandpanels/commandtags/tags/economy/SellItemTags.java
@@ -5,6 +5,7 @@ import me.realized.tokenmanager.api.TokenManager;
 import me.rockyhawk.commandpanels.CommandPanels;
 import me.rockyhawk.commandpanels.commandtags.CommandTagEvent;
 import me.rockyhawk.commandpanels.ioclasses.legacy.MinecraftVersions;
+import me.rockyhawk.commandpanels.openpanelsmanager.PanelPosition;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
@@ -34,10 +35,10 @@ public class SellItemTags implements Listener {
                 if (plugin.econ != null) {
                     boolean sold = removeItem(e.p, e.args);
                     if (!sold) {
-                        plugin.tex.sendMessage(e.p, plugin.config.getString("purchase.item.failure"));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.item.failure")).replaceAll("%cp-args%", e.args[1]));
                     } else {
                         plugin.econ.depositPlayer(e.p, Double.parseDouble(e.args[0]));
-                        plugin.tex.sendMessage(e.p, Objects.requireNonNull(plugin.config.getString("purchase.item.success")).replaceAll("%cp-args%", e.args[1]));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.item.success")).replaceAll("%cp-args%", e.args[1]));
                     }
                 } else {
                     plugin.tex.sendMessage(e.p, ChatColor.RED + "Selling Requires Vault and an Economy to work!");
@@ -56,11 +57,11 @@ public class SellItemTags implements Listener {
                     TokenManager api = (TokenManager) Bukkit.getServer().getPluginManager().getPlugin("TokenManager");
                     boolean sold = removeItem(e.p, e.args);
                     if (!sold) {
-                        plugin.tex.sendMessage(e.p, plugin.config.getString("purchase.item.failure"));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.item.failure")).replaceAll("%cp-args%", e.args[1]));
                     } else {
                         assert api != null;
                         api.addTokens(e.p, Long.parseLong(e.args[0]));
-                        plugin.tex.sendMessage(e.p, plugin.config.getString("purchase.item.success").replaceAll("%cp-args%", e.args[1]));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.item.success")).replaceAll("%cp-args%", e.args[1]));
                     }
                 } else {
                     plugin.tex.sendMessage(e.p, ChatColor.RED + "Selling Requires TokenManager to work!");
@@ -77,10 +78,10 @@ public class SellItemTags implements Listener {
                 if (plugin.getServer().getPluginManager().isPluginEnabled("CoinsAPINB")) {
                     boolean sold = removeItem(e.p, e.args);
                     if (!sold) {
-                        plugin.tex.sendMessage(e.p, plugin.config.getString("purchase.item.failure"));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.item.failure")).replaceAll("%cp-args%", e.args[1]));
                     } else {
                         CoinsAPI.addCoins(e.p.getUniqueId().toString(), (int) Long.parseLong(e.args[0]));
-                        plugin.tex.sendMessage(e.p, plugin.config.getString("purchase.item.success").replaceAll("%cp-args%", e.args[1]));
+                        plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.item.success")).replaceAll("%cp-args%", e.args[1]));
                     }
                 } else {
                     plugin.tex.sendMessage(e.p, ChatColor.RED + "Selling Requires CoinsAPINB to work!");


### PR DESCRIPTION
Adds PAPI Placeholder parsing to most if not all "Purchase"-related success/failure messages of CP Adds %cp-args% parsing to most if not all "Purchase"-related success/failure messages of CP

Tested on 1.19.2 with Paper Build 270 _(Yes, a little bit outdated)_ but should work on every Version which is supported by CP.