### PR TITLE
Added Config-Option to enable MiniMessage-CommandTag on Non-Paper forks + Warning

### DIFF
--- a/resource/config.yml
+++ b/resource/config.yml
@@ -18,6 +18,8 @@ config:
   stop-sound: true
   disabled-world-message: true
   panel-snooper: false
+  allow-unsafe-mini-message: false
+  disable-unsafe-mm-warning: false
   format:
     tag: '&6[&bCommandPanels&6] '
     perms: '&cNo permission.'

--- a/src/me/rockyhawk/commandpanels/CommandPanels.java
+++ b/src/me/rockyhawk/commandpanels/CommandPanels.java
@@ -272,6 +272,9 @@ public class CommandPanels extends JavaPlugin{
 
         //get tag
         tag = tex.colour(config.getString("config.format.tag"));
+        if(config.getBoolean("config.allow-unsafe-mini-message") && !config.getBoolean("config.disable-unsafe-mm-warning")){
+            Bukkit.getLogger().warning("[CommandPanels] Allow unsafe MiniMessage detected! Please proceed with caution as no support will be given for it!");
+        }
 
         Bukkit.getLogger().info("[CommandPanels] RockyHawk's CommandPanels v" + this.getDescription().getVersion() + " Plugin Loaded!");
     }

--- a/src/me/rockyhawk/commandpanels/commandtags/tags/standard/BasicTags.java
+++ b/src/me/rockyhawk/commandpanels/commandtags/tags/standard/BasicTags.java
@@ -142,7 +142,13 @@ public class BasicTags implements Listener {
                 Component parsedText = SerializerUtils.serializeText(String.join(" ",e.args));
                 player.sendMessage(parsedText);
             }else{
-                plugin.tex.sendString(e.p, plugin.tag + ChatColor.RED + "MiniMessage-Feature needs Paper 1.18 or newer to work!");
+                if(plugin.legacy.LOCAL_VERSION.greaterThanOrEqualTo(MinecraftVersions.v1_18) && plugin.config.getBoolean("config.allow-unsafe-mini-message")){
+                    Audience player = (Audience) e.p; // Needed because the basic Player from the Event can't send Paper's Components
+                    Component parsedText = SerializerUtils.serializeText(String.join(" ",e.args));
+                    player.sendMessage(parsedText);
+                }else{
+                    plugin.tex.sendString(e.p, plugin.tag + ChatColor.RED + "MiniMessage-Feature needs Paper 1.18 or newer to work!");
+                }
             }
         }
     }


### PR DESCRIPTION
1. Added Config Option to enable the Command Tag `minimessage=` for other Paper-forks on 1.18 or above.
2. Also added a Warning on Startup if that option is enabled. Can be disabled if the server owner intends to use a Paper-fork.


Config Options added:

- `allow-unsafe-mini-message` | Default: `false`
- `disable-unsafe-mm-warning` | Default: `false`

Tested on Spigot 1.19.3 and Paper 1.19.3.

Disclaimer: Command Panels only supports Paper and Spigot! Usage of other Forks is at own risk and no support is guaranteed.
