### PR TITLE
Added ArmorTrim Option and other changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.19.3-R0.1-SNAPSHOT</version>
+            <version>1.20-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/src/me/rockyhawk/commandpanels/classresources/ItemCreation.java
+++ b/src/me/rockyhawk/commandpanels/classresources/ItemCreation.java
@@ -345,27 +345,25 @@ public class ItemCreation {
                 }
             }
             // 1.20 Trim Feature for Player Armor
-            if(plugin.legacy.LOCAL_VERSION.greaterThanOrEqualTo(MinecraftVersions.v1_20)){
+            if(plugin.legacy.LOCAL_VERSION.greaterThanOrEqualTo(MinecraftVersions.v1_20) && itemSection.contains("trim")){
                 // trim: <Material> <Pattern>
-                if(itemSection.contains("trim")){
-                    String trim = itemSection.getString("trim");
-                    String[] trimList = trim.split("\\s");
-                    if(trimList.length == 2){
-                        String trimMaterialString = trimList[0].toLowerCase();
-                        String trimPatternString = trimList[1].toLowerCase();
+                String trim = itemSection.getString("trim");
+                String[] trimList = trim.split("\\s");
+                if(trimList.length == 2){
+                    String trimMaterialString = trimList[0].toLowerCase();
+                    String trimPatternString = trimList[1].toLowerCase();
 
-                        // Check if Material and Pattern are valid and the itemstack is an armor piece
-                        if(isTrimMaterial(trimMaterialString) && isTrimPattern(trimPatternString) && isArmor(s)){
+                    // Check if Material and Pattern are valid and the itemstack is an armor piece
+                    if(isTrimMaterial(trimMaterialString) && isTrimPattern(trimPatternString) && isArmor(s)){
 
-                            // Getting the correct Pattern and Material - Seems to be experimental this way
-                            // Material and Pattern don't have a valueOf-function to get them the easier way.
-                            TrimMaterial trimMaterial = Registry.TRIM_MATERIAL.get(Objects.requireNonNull(NamespacedKey.fromString("minecraft:" + trimMaterialString)));
-                            TrimPattern trimPattern = Registry.TRIM_PATTERN.get(Objects.requireNonNull(NamespacedKey.fromString("minecraft:" + trimPatternString)));
+                        // Getting the correct Pattern and Material - Seems to be experimental this way
+                        // Material and Pattern don't have a valueOf-function to get them the easier way.
+                        TrimMaterial trimMaterial = Registry.TRIM_MATERIAL.get(Objects.requireNonNull(NamespacedKey.fromString("minecraft:" + trimMaterialString)));
+                        TrimPattern trimPattern = Registry.TRIM_PATTERN.get(Objects.requireNonNull(NamespacedKey.fromString("minecraft:" + trimPatternString)));
 
-                            ArmorMeta armorMeta = (ArmorMeta) s.getItemMeta();
-                            armorMeta.setTrim(new ArmorTrim(trimMaterial, trimPattern));
-                            s.setItemMeta(armorMeta);
-                        }
+                        ArmorMeta armorMeta = (ArmorMeta) s.getItemMeta();
+                        armorMeta.setTrim(new ArmorTrim(trimMaterial, trimPattern));
+                        s.setItemMeta(armorMeta);
                     }
                 }
             }

--- a/src/me/rockyhawk/commandpanels/classresources/placeholders/Placeholders.java
+++ b/src/me/rockyhawk/commandpanels/classresources/placeholders/Placeholders.java
@@ -1,6 +1,6 @@
 package me.rockyhawk.commandpanels.classresources.placeholders;
 
-import com.bencodez.votingplugin.user.UserManager;
+import com.bencodez.votingplugin.VotingPluginHooks;
 import com.earth2me.essentials.Essentials;
 import me.realized.tokenmanager.api.TokenManager;
 import me.rockyhawk.commandpanels.CommandPanels;
@@ -378,7 +378,7 @@ public class Placeholders {
         }
         if (plugin.getServer().getPluginManager().isPluginEnabled("VotingPlugin")) {
             if(identifier.equals("votingplugin-points")) {
-                return String.valueOf(UserManager.getInstance().getVotingPluginUser(p).getPoints());
+                return String.valueOf(VotingPluginHooks.getInstance().getUserManager().getVotingPluginUser(p).getPoints());
             }
         }
         //end nodes with PlaceHolders


### PR DESCRIPTION
- Update Code to newer VotingPlugin API
- Update Spigot API to 1.20-R0.1-SNAPSHOT
- Add ArmorTrim Option for Item Settings

### ArmorTrim Option
Adding `trim: <Material> <Pattern>` to the item-settings will add the newly added Trims to any armor which can be customized by those.

List of those can be found here: [Trim Pattern](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/inventory/meta/trim/TrimPattern.html) and [Trim Material](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/inventory/meta/trim/TrimMaterial.html)

The new Option was tested on a Minecraft _**1.20.1**_ Server running _**Paper Build 58**_.