### PR TITLE
Fix Error with Custom Heads on 1.20.2

### DIFF
--- a/src/me/rockyhawk/commandpanels/classresources/GetCustomHeads.java
+++ b/src/me/rockyhawk/commandpanels/classresources/GetCustomHeads.java
@@ -128,7 +128,7 @@ public class GetCustomHeads {
     @SuppressWarnings("deprecation")
     public ItemStack getCustomHead(String b64stringtexture) {
         //get head from base64
-        GameProfile profile = new GameProfile(UUID.randomUUID(), null);
+        GameProfile profile = new GameProfile(UUID.randomUUID(), "");
         PropertyMap propertyMap = profile.getProperties();
         if (propertyMap == null) {
             throw new IllegalStateException("Profile doesn't contain a property map");


### PR DESCRIPTION
This PR fixes the NullPointerException with Custom Heads in Minecraft 1.20.2.

Tested with Paper **(1.20.1 Build 196 & 1.20.2 Build 207)** and Spigot **(1.20.2 Build 3904-Spigot-224dad5-1bf30a4)**.