### PR TITLE
Implement toggle for disabling the Import Command.

### DIFF
--- a/resource/config.yml
+++ b/resource/config.yml
@@ -17,6 +17,7 @@ config:
   disabled-world-message: true
   panel-snooper: false
   allow-unsafe-mini-message: false
+  enable-import-command: false
   format:
     tag: '&6[&bCommandPanels&6] '
     perms: '&cNo permission.'
@@ -28,6 +29,7 @@ config:
     offline: 'Offline'
     offlineHeadValue: 'eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNmU1Mjg2YzQ3MGY2NmZmYTFhMTgzMzFjYmZmYjlhM2MyYTQ0MjRhOGM3MjU5YzQ0MzZmZDJlMzU1ODJhNTIyIn19fQ=='
     input: '&cYour Input is too long!'
+    disabled: '&cThis feature is disabled in your plugin config.'
 input:
   input-cancel: cancel
   input-cancelled: '&cCancelled!'

--- a/src/me/rockyhawk/commandpanels/commands/CommandPanelImport.java
+++ b/src/me/rockyhawk/commandpanels/commands/CommandPanelImport.java
@@ -18,6 +18,10 @@ public class CommandPanelImport implements CommandExecutor {
     @Override
     public boolean onCommand(CommandSender sender, Command cmd, String label, String[] args) {
         if (sender.hasPermission("commandpanel.import")) {
+            if(!plugin.config.getString("config.enable-import-command").equalsIgnoreCase("true")){
+                sender.sendMessage(plugin.tex.colour(plugin.tag + plugin.config.getString("config.format.disabled")));
+                return true;
+            }
             if (args.length == 2) {
                 //import command
                 new BukkitRunnable() {


### PR DESCRIPTION
Implements the config toggle `enable-import-command` which is set to `false` in the default configuration.

This is meant to increase security for server owners which don't make use of that feature.
Everyone who wants to use this feature can just enable it by setting the toggle to `true`.

Server used for testing: `Minecraft 1.20.4 with paper-1.20.4-381` but should work on any version with this feature.