### PR TITLE
Disabled /cpg nbt auto grabber as its causing issues.

### DIFF
--- a/src/me/rockyhawk/commandpanels/classresources/ItemCreation.java
+++ b/src/me/rockyhawk/commandpanels/classresources/ItemCreation.java
@@ -485,13 +485,13 @@ public class ItemCreation {
                 if(plugin.legacy.LOCAL_VERSION.greaterThanOrEqualTo(MinecraftVersions.v1_14)){
                     file.set("panels." + panelName + ".item." + i + ".customdata", Objects.requireNonNull(cont.getItemMeta()).getCustomModelData());
                 }
-                try {
-                    ReadWriteNBT nbt = NBT.itemStackToNBT(cont);
-                    file.set("panels." + panelName + ".item." + i + ".nbt", nbt.toString());
-                }catch(Exception ignore){
-                    //no nbt or error
-                    file.set("panels." + panelName + ".item." + i + ".nbt", null);
-                }
+//                try {
+//                    ReadWriteNBT nbt = NBT.itemStackToNBT(cont);
+//                    file.set("panels." + panelName + ".item." + i + ".nbt", nbt.toString());
+//                }catch(Exception ignore){
+//                    //no nbt or error
+//                    file.set("panels." + panelName + ".item." + i + ".nbt", null);
+//                }
             }catch(Exception n){
                 //skip over an item that spits an error
             }


### PR DESCRIPTION
Commented out the nbt part of cpg due to how its causing errors on panels just created since material and such is not removed from the nbt. Needs a way to ONLY show custom nbt data.