### PR TITLE
Hasperm null fix

### DIFF
--- a/src/me/rockyhawk/commandpanels/classresources/HasSections.java
+++ b/src/me/rockyhawk/commandpanels/classresources/HasSections.java
@@ -12,6 +12,7 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 
 public class HasSections {
     CommandPanels plugin;
@@ -119,7 +120,11 @@ public class HasSections {
         //the current has section with all the functions implemented inside it
         if(setName.startsWith("has")) {
             if(value.endsWith(" HASPERM")) {
-                return Bukkit.getPlayer(value.substring(0, value.length()-8)).hasPermission(compare) == outputValue;
+                String playername = value.substring(0, value.length()-8);
+                Player player = Bukkit.getPlayerExact(playername);
+                if(player != null){
+                    return player.hasPermission(compare) == outputValue;
+                }
             }else if(value.endsWith(" ISGREATER")) {
                 return (new BigDecimal(compare).compareTo(new BigDecimal(value.substring(0, value.length()-10).replace(",",""))) <= 0 == outputValue);
             }else{

--- a/src/me/rockyhawk/commandpanels/classresources/HasSections.java
+++ b/src/me/rockyhawk/commandpanels/classresources/HasSections.java
@@ -12,7 +12,6 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Objects;
 
 public class HasSections {
     CommandPanels plugin;


### PR DESCRIPTION
Fixed hasperm crashing panels on null player. Now it will automatically return as false if no player is found in the check. This allows panels with player input to be open without the placeholder thats being checked by the hasperm.

Will be last quick fix before i start work on nbt system.