### PR TITLE
Fix for %cp-material-slot% and legacy ids.

### DIFF
--- a/src/me/rockyhawk/commandpanels/classresources/placeholders/Placeholders.java
+++ b/src/me/rockyhawk/commandpanels/classresources/placeholders/Placeholders.java
@@ -191,7 +191,7 @@ public class Placeholders {
                     material = p.getOpenInventory().getTopInventory().getItem((int)Double.parseDouble(matNumber)).getType().toString();
                     if (plugin.legacy.LOCAL_VERSION.lessThanOrEqualTo(MinecraftVersions.v1_12)) {
                         //add the ID to the end if it is legacy (eg, material:id)
-                        material = material + ":" + p.getOpenInventory().getTopInventory().getItem((int)Double.parseDouble(matNumber)).getType().getId();
+                        material = material + ":" + p.getOpenInventory().getTopInventory().getItem((int)Double.parseDouble(matNumber)).getData().getData();
                     }
                 } catch (NullPointerException er) {
                     material = "AIR";

--- a/src/me/rockyhawk/commandpanels/openwithitem/UtilsOpenWithItem.java
+++ b/src/me/rockyhawk/commandpanels/openwithitem/UtilsOpenWithItem.java
@@ -77,10 +77,18 @@ public class UtilsOpenWithItem implements Listener {
         }
 
         Player p = e.getPlayer();
-        if(plugin.hotbar.itemCheckExecute(e.getPlayer().getInventory().getItemInMainHand(),p,false,false)){
-            e.setCancelled(true);
-            p.updateInventory();
+        if(Bukkit.getVersion().contains("1.8")){
+            if(plugin.hotbar.itemCheckExecute(e.getPlayer().getItemInHand(),p,false,false)){
+                e.setCancelled(true);
+                p.updateInventory();
+            }
+        }else{
+            if(plugin.hotbar.itemCheckExecute(e.getPlayer().getInventory().getItemInMainHand(),p,false,false)){
+                e.setCancelled(true);
+                p.updateInventory();
+            }
         }
+
     }
     @EventHandler
     public void onWorldChange(PlayerChangedWorldEvent e){


### PR DESCRIPTION
Quick hotfix for %cp-material-slot% not returning correctly on legacy clients.