### PR TITLE
Fixes to mmo= paywalls, multipaywalls, minor changes to item-paywall=

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -33,6 +33,7 @@ body:
         - 1.17
         - 1.18
         - 1.19
+        - 1.20
     validations:
      required: true
   - type: dropdown
@@ -41,6 +42,9 @@ body:
       label: What CommandPanels version are you using?
       options:
         - latest
+        - 3.20.0.3
+        - 3.20.0.2
+        - 3.20.0.1
         - 3.19.0.3
         - 3.19.0.2
         - 3.19.0.1
@@ -66,16 +70,6 @@ body:
         - 3.17.4.1
         - 3.17.4.0
         - 3.17.3.1
-        - 3.17.3.0
-        - 3.17.2.2
-        - 3.17.2.1
-        - 3.17.2.0
-        - 3.17.1.5
-        - 3.17.1.4
-        - 3.17.1.3
-        - 3.17.1.2
-        - 3.17.1.1
-        - 3.17.1.0
         - Any other version
     validations:
      required: true

--- a/.github/ISSUE_TEMPLATE/need-help.yml
+++ b/.github/ISSUE_TEMPLATE/need-help.yml
@@ -31,6 +31,7 @@ body:
         - 1.17
         - 1.18
         - 1.19
+        - 1.20
     validations:
       required: true
   - type: dropdown
@@ -39,6 +40,9 @@ body:
       label: What CommandPanels version are you using?
       options:
         - latest
+        - 3.20.0.3
+        - 3.20.0.2
+        - 3.20.0.1
         - 3.19.0.3
         - 3.19.0.2
         - 3.19.0.1
@@ -64,16 +68,6 @@ body:
         - 3.17.4.1
         - 3.17.4.0
         - 3.17.3.1
-        - 3.17.3.0
-        - 3.17.2.2
-        - 3.17.2.1
-        - 3.17.2.0
-        - 3.17.1.5
-        - 3.17.1.4
-        - 3.17.1.3
-        - 3.17.1.2
-        - 3.17.1.1
-        - 3.17.1.0
         - Any other version
     validations:
       required: true

--- a/src/me/rockyhawk/commandpanels/classresources/ItemCreation.java
+++ b/src/me/rockyhawk/commandpanels/classresources/ItemCreation.java
@@ -523,6 +523,14 @@ public class ItemCreation {
                 }
             }
         }catch(Exception ignore){}
+        //check for custom model data
+        try {
+            if (one.getItemMeta().getCustomModelData() != (two.getItemMeta().getCustomModelData())) {
+                if(one.getItemMeta().hasCustomModelData()) {
+                    return false;
+                }
+            }
+        }catch(Exception ignore){}
         //check for nbt
         if(nbtCheck) {
             try {


### PR DESCRIPTION
Fix for Half on mmo= paywall=, multipaywall w/custom items, added IGNORENBT to item-paywall= for edge cases like spawner types ONLY WORKS ON NORMAL MATERIAL CHECKS

Half items should not happen with mmo= custom items in item paywalls anymore. This was caused by the main section checking before the mmo= section checked. Now it only checks mmo= if its an mmo= and does not continue to the main custom item check after.

Multipaywall was fixed due to custom model data not being taken into account on IsIdentical check.

IGNORENBT was added as a simple .contains check in item-paywall so that if you want to require spawners of any type in a spawner check it can work. ONLY WORKS ON NORMAL MATERIAL CHECKS NOT CUSTOM ITEM SECTIONS!

Also reduced version options for github down to last ingame editor version and latest cp version. Also added 1.20 as version selection.