### PR TITLE
Changes to item-paywall=

### DIFF
--- a/src/me/rockyhawk/commandpanels/classresources/ItemCreation.java
+++ b/src/me/rockyhawk/commandpanels/classresources/ItemCreation.java
@@ -47,7 +47,7 @@ public class ItemCreation {
             return null;
         }
         ItemStack s = null;
-        boolean hideAttributes = true;
+        boolean hideAttributes = false;
         String mat;
         String matraw;
         String skullname;
@@ -168,7 +168,7 @@ public class ItemCreation {
             if(itemSection.contains("itemType")){
                 //if hidden, reverse
                 if(itemSection.getStringList("itemType").contains("noAttributes")){
-                    hideAttributes = false;
+                    hideAttributes = true; /// Swapped for better isIdentical checks.
                 }
                 if(itemSection.getStringList("itemType").contains("noNBT")){
                     addNBT = false;
@@ -348,7 +348,7 @@ public class ItemCreation {
             p.sendMessage(plugin.tex.colour(plugin.tag + plugin.config.getString("config.format.error") + " material: " + itemSection.getString("material")));
             return null;
         }
-        plugin.setName(panel,s, itemSection.getString("name"), itemSection.getStringList("lore"), p, placeholders, colours, hideAttributes);
+        s = plugin.setName(panel,s, itemSection.getString("name"), itemSection.getStringList("lore"), p, placeholders, colours, hideAttributes);
         return s;
     }
 

--- a/src/me/rockyhawk/commandpanels/nbt/NBTManager.java
+++ b/src/me/rockyhawk/commandpanels/nbt/NBTManager.java
@@ -33,6 +33,7 @@ public class NBTManager {
     public String getData(ItemStack item, String key){
         NBTItem nbti = new NBTItem(item);
         if(!nbti.hasNBTData()) return "";
-        return nbti.getString(key);
+        //nbti.getOrDefault(key, "");
+        return nbti.getOrDefault(key, "");
     }
 }


### PR DESCRIPTION
Changes to the logic for item-paywall= Uses IsIdentical check instead of the other checks we were doing and uses the GenerateItemFromConfig to make the sell item even with mmo= and custom items.

Changes to the noAttributes tag and how it works. Instead of turning off the hiding noAttributes now hides them instead.

Addition quick change to the nbtmanager to get the correct type instead of always string. Unsure on if this affects anything since i have not tested it.