### PR TITLE
Additional placeholders - name-slot, lore-slot AND hasnoperm=

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <repositories>
         <repository>
             <id>io.papermc</id>
-            <url>https://papermc.io/repo/repository/maven-releases/</url>
+            <url>https://repo.papermc.io/repository/maven-public/</url>
         </repository>
         <repository>
             <id>jitpack.io</id>

--- a/src/me/rockyhawk/commandpanels/CommandPanels.java
+++ b/src/me/rockyhawk/commandpanels/CommandPanels.java
@@ -6,6 +6,7 @@ import io.lumine.mythic.lib.api.item.NBTItem;
 import me.rockyhawk.commandpanels.api.CommandPanelsAPI;
 import me.rockyhawk.commandpanels.api.Panel;
 import me.rockyhawk.commandpanels.classresources.ExecuteOpenVoids;
+import me.rockyhawk.commandpanels.classresources.SerializerUtils;
 import me.rockyhawk.commandpanels.classresources.customheads.GetCustomHeads;
 import me.rockyhawk.commandpanels.classresources.HasSections;
 import me.rockyhawk.commandpanels.classresources.ItemCreation;
@@ -364,7 +365,12 @@ public class CommandPanels extends JavaPlugin{
                 }
             }
             if (customName != null) {
-                renamedMeta.setDisplayName(customName);
+                if(SerializerUtils.isPaperServer()){
+                    renamedMeta.setDisplayName(SerializerUtils.doMiniMessageLegacy(customName));
+                } else {
+                    renamedMeta.setDisplayName(customName);
+                }
+
             }
 
             List<String> re_lore;
@@ -378,7 +384,11 @@ public class CommandPanels extends JavaPlugin{
                 }else{
                     re_lore = lore;
                 }
-                renamedMeta.setLore(splitListWithEscape(re_lore));
+                if(SerializerUtils.isPaperServer()){
+                    renamedMeta.setLore(SerializerUtils.doMiniMessageLegacy(re_lore));
+                } else {
+                    renamedMeta.setLore(splitListWithEscape(re_lore));
+                }
             }
             renamed.setItemMeta(renamedMeta);
         } catch (Exception ignored) {}

--- a/src/me/rockyhawk/commandpanels/classresources/SerializerUtils.java
+++ b/src/me/rockyhawk/commandpanels/classresources/SerializerUtils.java
@@ -1,11 +1,92 @@
 package me.rockyhawk.commandpanels.classresources;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.TextDecoration;
 import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import org.bukkit.Bukkit;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class SerializerUtils {
 
-    public static Component serializeText(String msg){
-        return MiniMessage.miniMessage().deserialize(msg);
+    static LegacyComponentSerializer legacyComponentSerializer;
+
+    //public static Component serializeText(String msg){
+    //    return MiniMessage.miniMessage().deserialize(msg);
+    //}
+
+    public static boolean isPaperServer(){
+        try {
+            // Check for a class that exists only in Paper
+            Class.forName("com.destroystokyo.paper.PaperConfig");
+            return true;
+        } catch (ClassNotFoundException e) {
+            // The class was not found, indicating a non-Paper server
+            return false;
+        }
+    }
+
+    public static Component doMiniMessage(String string) {
+        legacyComponentSerializer = LegacyComponentSerializer.builder().hexColors().character('&').build();
+        Component component = legacyComponentSerializer.deserialize(string.replace('§', '&'));
+
+        return MiniMessage.miniMessage().deserialize(MiniMessage.miniMessage().serialize(component.decoration(TextDecoration.ITALIC, false))
+                .replace("\\<", "<").replace("\\", "").replace("\n", "<br>")).decoration(TextDecoration.ITALIC, false);
+    }
+
+    public static List<Component> doMiniMessage(List<String> strings) {
+        return strings.stream()
+                .map(SerializerUtils::doMiniMessage)
+                .collect(Collectors.toList());
+    }
+
+    public static String doMiniMessageLegacy(String string) {
+        MiniMessage miniMessage = MiniMessage.miniMessage();
+        Component component = miniMessage.deserialize(string);
+
+        Bukkit.getLogger().info("Component: " + component);
+
+        String legacyText = LegacyComponentSerializer.builder()
+                .character('&')
+                .hexColors()
+                .build()
+                .serialize(component);
+
+        Bukkit.getLogger().info("Legacy: " + legacyText);
+
+        Bukkit.getLogger().info("Convert: " + convertHexCodes(legacyText));
+
+        return convertHexCodes(legacyText);
+    }
+
+    public static List<String> doMiniMessageLegacy(List<String> strings) {
+        return strings.stream()
+                .map(SerializerUtils::doMiniMessageLegacy)
+                .collect(Collectors.toList());
+    }
+
+    // Helper method to convert &x&F&F&F&F&F&F to &#FFFFFF format
+    private static String convertHexCodes(String text) {
+        StringBuilder result = new StringBuilder();
+        char[] chars = text.toCharArray();
+
+        for (int i = 0; i < chars.length; i++) {
+            // Check for the start of a hex color code (&x pattern)
+            if (chars[i] == '&' && i + 1 < chars.length && chars[i + 1] == 'x' && i + 13 <= chars.length) {
+                // Found a hex color code
+                StringBuilder hexCode = new StringBuilder("&#");
+                for (int j = 2; j < 14; j += 2) {
+                    hexCode.append(chars[i + j]);
+                }
+                result.append(hexCode.toString());
+                i += 13; // Skip the next 12 characters (full hex code)
+            } else {
+                result.append(chars[i]);
+            }
+        }
+
+        return result.toString();
     }
 }

--- a/src/me/rockyhawk/commandpanels/classresources/placeholders/Placeholders.java
+++ b/src/me/rockyhawk/commandpanels/classresources/placeholders/Placeholders.java
@@ -211,6 +211,52 @@ public class Placeholders {
                 return "";
             }
         }
+        //get name value from slot in current open inventory (panel)
+        if(identifier.startsWith("name-")) {
+            try {
+                String nameNumber = identifier.replace("name-", "");
+                String name;
+                try {
+                    ItemStack item = p.getOpenInventory().getTopInventory().getItem((int)Double.parseDouble(nameNumber));
+                    name = item.getType().toString().replace("_"," ");
+                    if(item.hasItemMeta()){
+                        if(item.getItemMeta().hasDisplayName()){
+                            name = item.getItemMeta().getDisplayName();
+                        }
+                    }
+                } catch (NullPointerException er) {
+                    name = "";
+                }
+                return name;
+            } catch (Exception ex) {
+                plugin.debug(ex,p);
+                return "";
+            }
+        }
+        //get lore value from slot in current open inventory (panel)
+        if(identifier.startsWith("lore-")) {
+            try {
+                String loreNumber = identifier.replace("lore-", "");
+                String lore = "";
+                try {
+                    ItemStack item = p.getOpenInventory().getTopInventory().getItem((int)Double.parseDouble(loreNumber));
+                    if(item.hasItemMeta()){
+                        if(item.getItemMeta().hasLore()){
+                            List<String> ListLore = item.getItemMeta().getLore();
+                            for(String list : ListLore){
+                                lore = lore + list + "\n";
+                            }
+                        }
+                    }
+                } catch (NullPointerException er) {
+                    lore = "";
+                }
+                return lore;
+            } catch (Exception ex) {
+                plugin.debug(ex,p);
+                return "";
+            }
+        }
         //get stack amount from slot in current open inventory (panel)
         if(identifier.startsWith("stack-")) {
             try {

--- a/src/me/rockyhawk/commandpanels/commandtags/paywalls/Hasperm.java
+++ b/src/me/rockyhawk/commandpanels/commandtags/paywalls/Hasperm.java
@@ -31,5 +31,20 @@ public class Hasperm implements Listener {
                 e.PAYWALL_OUTPUT = PaywallOutput.Blocked;
             }
         }
+
+        if(e.name.equalsIgnoreCase("hasnoperm=")){
+            //if player uses hasnoperm= [perm]
+            if (!e.p.hasPermission(e.args[0])) {
+                if (plugin.config.getBoolean("purchase.permission.enable") && e.doDelete) {
+                    plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.permission.success")).replaceAll("%cp-args%", e.args[0]));
+                }
+                e.PAYWALL_OUTPUT = PaywallOutput.Passed;
+            } else {
+                if (plugin.config.getBoolean("purchase.currency.enable")) {
+                    plugin.tex.sendString(e.panel, PanelPosition.Top, e.p, Objects.requireNonNull(plugin.config.getString("purchase.permission.failure")));
+                }
+                e.PAYWALL_OUTPUT = PaywallOutput.Blocked;
+            }
+        }
     }
 }

--- a/src/me/rockyhawk/commandpanels/commandtags/tags/standard/BasicTags.java
+++ b/src/me/rockyhawk/commandpanels/commandtags/tags/standard/BasicTags.java
@@ -140,7 +140,7 @@ public class BasicTags implements Listener {
             //do mini message if conditions are met
             if (plugin.legacy.MAJOR_VERSION.greaterThanOrEqualTo(MinecraftVersions.v1_18)) {
                 Audience player = (Audience) e.p; // Needed because the basic Player from the Event can't send Paper's Components
-                Component parsedText = SerializerUtils.serializeText(String.join(" ", e.args));
+                Component parsedText = SerializerUtils.doMiniMessage(String.join(" ", e.args));
                 player.sendMessage(parsedText);
             } else {
                 plugin.tex.sendString(e.p, plugin.tag + ChatColor.RED + "MiniMessage-Feature needs Paper 1.18 or newer to work!");

--- a/src/me/rockyhawk/commandpanels/openpanelsmanager/OpenGUI.java
+++ b/src/me/rockyhawk/commandpanels/openpanelsmanager/OpenGUI.java
@@ -50,6 +50,8 @@ public class OpenGUI {
         Set<String> itemList = pconfig.getConfigurationSection("item").getKeys(false);
         HashSet<Integer> takenSlots = new HashSet<>();
         for (String item : itemList) {
+            item = plugin.tex.attachPlaceholders(panel,position,p,item);
+            Bukkit.getLogger().info("formatted number: " + item);
             String section = "";
             //openType needs to not be 3 so the editor won't include hasperm and hasvalue, etc items
             section = plugin.has.hasSection(panel,position,pconfig.getConfigurationSection("item." + Integer.parseInt(item)), p);


### PR DESCRIPTION
Added `%cp-name-<slot>%` which will return the name of the item in that slot. If no name it will use item type like COBBLESTONE
Added `%cp-lore-<slot>%` which returns the lore for the slot with \n added to the ends of each line as a spacer/splitter. EXAMPLE:
```
lore:
- hello world
- this is me
```
would return `"hello world\nthis is me"` and
```
lore:
- hello world
```
Would return `"hello world\n"`
both return `""` if empty/does not exist.