### PR TITLE
Minimessage old vs new fix.

### DIFF
--- a/src/me/rockyhawk/commandpanels/Utils.java
+++ b/src/me/rockyhawk/commandpanels/Utils.java
@@ -117,7 +117,11 @@ public class Utils implements Listener {
 
         //if an item has an area for input instead of commands
         if(panel.getConfig().contains("item." + foundSlot + section + ".player-input")) {
-            plugin.inputUtils.playerInput.put(p,new PlayerInput(panel,panel.getConfig().getStringList("item." + foundSlot + section + ".player-input"),e.getClick()));
+            List<String> cancelCommands = null;
+            if(panel.getConfig().contains("item." + foundSlot + section + ".player-canceled-input")){
+                cancelCommands = panel.getConfig().getStringList("item." + foundSlot + section + ".player-canceled-input");
+            }
+            plugin.inputUtils.playerInput.put(p,new PlayerInput(panel,panel.getConfig().getStringList("item." + foundSlot + section + ".player-input"),cancelCommands,e.getClick()));
             plugin.inputUtils.sendMessage(panel,position,p);
         }
 

--- a/src/me/rockyhawk/commandpanels/classresources/ExecuteOpenVoids.java
+++ b/src/me/rockyhawk/commandpanels/classresources/ExecuteOpenVoids.java
@@ -92,7 +92,13 @@ public class ExecuteOpenVoids {
                     //play sound when panel is opened
                     if(!Objects.requireNonNull(panel.getConfig().getString("sound-on-open")).equalsIgnoreCase("off")) {
                         try {
-                            p.playSound(p.getLocation(), Sound.valueOf(Objects.requireNonNull(panel.getConfig().getString("sound-on-open")).toUpperCase()), 1F, 1F);
+                            String[] args = Objects.requireNonNull(panel.getConfig().getString("sound-on-open")).split(" ");
+                            if(args.length >= 3){
+                                //sound on open volume and pitch: sound-on-open: minecraft:villager 1.0 0.5
+                                p.playSound(p.getLocation(), Sound.valueOf(args[0].toUpperCase()), Float.parseFloat(args[1]), Float.parseFloat(args[2]));
+                            } else {
+                                p.playSound(p.getLocation(), Sound.valueOf(Objects.requireNonNull(panel.getConfig().getString("sound-on-open")).toUpperCase()), 1F, 1F);
+                            }
                         } catch (Exception s) {
                             p.sendMessage(plugin.tex.colour(plugin.tag + plugin.config.getString("config.format.error") + " " + "sound-on-open: " + panel.getConfig().getString("sound-on-open")));
                         }

--- a/src/me/rockyhawk/commandpanels/classresources/MiniMessageUtils.java
+++ b/src/me/rockyhawk/commandpanels/classresources/MiniMessageUtils.java
@@ -24,7 +24,19 @@ public class MiniMessageUtils {
      */
 
     public String doMiniMessageLegacy(String string) {
-        MiniMessage miniMessage = MiniMessage.miniMessage();
+        MiniMessage miniMessage;
+        try {
+            // Try the newer method first
+            miniMessage = (MiniMessage) MiniMessage.class.getMethod("miniMessage").invoke(null);
+        } catch (Exception e) {
+            try {
+                // Fallback to older method
+                miniMessage = (MiniMessage) MiniMessage.class.getMethod("get").invoke(null);
+            } catch (Exception ex) {
+                return string; // Return raw text if no method exists
+            }
+        }
+
         try {
             Component component = miniMessage.deserialize(string);
             return LegacyComponentSerializer.builder()

--- a/src/me/rockyhawk/commandpanels/commandtags/tags/other/SpecialTags.java
+++ b/src/me/rockyhawk/commandpanels/commandtags/tags/other/SpecialTags.java
@@ -149,6 +149,33 @@ public class SpecialTags implements Listener {
                 }
             }.runTaskTimer(plugin, delayTicks, 1); //20 ticks == 1 second
         }
+        if(e.name.equalsIgnoreCase("eval-delay=")) {
+            //Eval delay is used to check if a placeholder equals the same after a delay.
+            //Format eval-delay= 20 %hello_world% console= give %cp-player-name% diamond 1
+            e.commandTagUsed();
+            //if player uses op= it will perform command as op
+            final int delayTicks = Integer.parseInt(e.args[0]);
+            final String staticValue = e.raw[1];
+            final String parsedValue = plugin.tex.placeholders(e.panel, e.pos, e.p, e.args[1].trim());
+            e.p.sendMessage(staticValue + " " + parsedValue);
+            String finalCommand = String.join(" ",e.args).replaceFirst(e.args[0],"").replaceFirst(e.args[1],"").trim();
+            new BukkitRunnable() {
+                @Override
+                public void run() {
+                    try {
+                        //If old parsed value does not equal the new value after delay then stop execute.
+                        if(plugin.tex.placeholders(e.panel, e.pos, e.p, staticValue.trim()).equals(parsedValue)){
+                            plugin.commandRunner.runCommand(e.panel,e.pos, e.p, finalCommand);
+                        }
+                    } catch (Exception ex) {
+                        //if there are any errors, cancel so that it doesn't loop errors
+                        plugin.debug(ex, e.p);
+                        this.cancel();
+                    }
+                    this.cancel();
+                }
+            }.runTaskTimer(plugin, delayTicks, 1); //20 ticks == 1 second
+        }
     }
 
     private Character[] convertToCharacterArray(char[] charArray) {

--- a/src/me/rockyhawk/commandpanels/commandtags/tags/standard/BungeeTags.java
+++ b/src/me/rockyhawk/commandpanels/commandtags/tags/standard/BungeeTags.java
@@ -30,7 +30,16 @@ public class  BungeeTags implements Listener {
             e.commandTagUsed();
             Player player = Bukkit.getPlayerExact(e.p.getName());
             assert player != null;
-            if (player.hasPermission("bungeecord.command.server." + e.args[0].toLowerCase())) {
+            if(e.args.length >= 2){
+                //This uses custom permission: server= servername permission
+                if(player.hasPermission(e.args[1])){
+                    //this contacts bungee and tells it to send the server change command whilst checking for CUSTOM permissions
+                    ByteArrayDataOutput out = ByteStreams.newDataOutput();
+                    out.writeUTF("Connect");
+                    out.writeUTF(e.args[0]);
+                    player.sendPluginMessage(plugin, "BungeeCord", out.toByteArray());
+                }
+            }else if (player.hasPermission("bungeecord.command.server." + e.args[0].toLowerCase())) {
                 //this contacts bungee and tells it to send the server change command whilst checking for permissions
                 ByteArrayDataOutput out = ByteStreams.newDataOutput();
                 out.writeUTF("Connect");

--- a/src/me/rockyhawk/commandpanels/interactives/input/PlayerInput.java
+++ b/src/me/rockyhawk/commandpanels/interactives/input/PlayerInput.java
@@ -9,10 +9,12 @@ public class PlayerInput {
     public Panel panel;
     public ClickType click;
     public List<String> commands;
+    public List<String> cancelCommands;
 
-    public PlayerInput(Panel panel1, List<String> commands1, ClickType click1){
+    public PlayerInput(Panel panel1, List<String> commands1, List<String> cancelCommands1, ClickType click1){
         panel = panel1;
         click = click1;
         commands = commands1;
+        cancelCommands = cancelCommands1;
     }
 }

--- a/src/me/rockyhawk/commandpanels/interactives/input/UserInputUtils.java
+++ b/src/me/rockyhawk/commandpanels/interactives/input/UserInputUtils.java
@@ -28,7 +28,19 @@ public class UserInputUtils implements Listener {
             e.setCancelled(true);
             if(e.getMessage().equalsIgnoreCase(plugin.config.getString("input.input-cancel"))){
                 e.getPlayer().sendMessage(plugin.tex.colour( Objects.requireNonNull(plugin.config.getString("input.input-cancelled"))));
-                playerInput.remove(e.getPlayer());
+                if(playerInput.get(e.getPlayer()).cancelCommands != null){
+                    plugin.getServer().getScheduler().scheduleSyncDelayedTask(plugin, new Runnable() {
+                        public void run() {
+                            if(playerInput.get(e.getPlayer()).cancelCommands != null){
+                                plugin.commandRunner.runCommands(playerInput.get(e.getPlayer()).panel, PanelPosition.Top,e.getPlayer(), playerInput.get(e.getPlayer()).cancelCommands,playerInput.get(e.getPlayer()).click); //I have to do this to run regular Bukkit voids in an ASYNC Event
+                                playerInput.remove(e.getPlayer());
+                            }
+                        }
+                    });
+                } else {
+                    playerInput.remove(e.getPlayer());
+                }
+
                 return;
             }
             playerInput.get(e.getPlayer()).panel.placeholders.addPlaceholder("player-input",e.getMessage());


### PR DESCRIPTION
Some versions of purpur used an older version of minimessage which used a slighly different method to call it. Added a check to see which method it uses and falls back to nothing if not found as it would crash the plugin on start if it was not found.