### PR TITLE
Enchanted minecraft namespace bug

### DIFF
--- a/src/me/rockyhawk/commandpanels/classresources/ItemCreation.java
+++ b/src/me/rockyhawk/commandpanels/classresources/ItemCreation.java
@@ -296,7 +296,7 @@ public class ItemCreation {
                             String enchant = enchantment.split("\\s")[0];
                             NamespacedKey key = enchant.contains(":") ?
                                     NamespacedKey.fromString(enchant) :
-                                    NamespacedKey.minecraft(enchant);
+                                    NamespacedKey.minecraft(enchant.toLowerCase());
                             EnchantMeta.addEnchant(Objects.requireNonNull(EnchantmentWrapper.getByKey(key)), Integer.parseInt(enchantment.split("\\s")[1]), true);
                         }
                         s.setItemMeta(EnchantMeta);


### PR DESCRIPTION
Enchanted: was not working with 
enchanted:
- SHARPNESS 5
added a toLowerCase to solve that issue. Did not add to custom namespaces tho.