### PR TITLE
fix itemstack amount error when pickup item with middle panel.

### DIFF
--- a/src/me/rockyhawk/commandpanels/inventory/InventorySaver.java
+++ b/src/me/rockyhawk/commandpanels/inventory/InventorySaver.java
@@ -136,7 +136,7 @@ public class InventorySaver implements Listener {
                     found = true;
                     break;
                 }
-                if(cont.get(i).isSimilar(item)){
+                if(cont.get(i).getAmount() < cont.get(i).getMaxStackSize() && cont.get(i).isSimilar(item)){
                     cont.get(i).setAmount(cont.get(i).getAmount() + item.getAmount());
                     found = true;
                     break;


### PR DESCRIPTION
on item pickup, the maxstacks of items is not determined, which may cause some problems.
When a player switches from one menu of top+middle+bottom to another of top+middle+bottom, the item pickup event will be triggered. Then the listener only determines whether there are similar items in the player's backpack, which will result in the appearance of an iron sword with an amount of 2.


```
panels: 
  Main_2_Top:
    perm: default
    rows: 5
    title: Example
    custom-item:
      airs:
        material: AIR
    commands-on-open:
    - open= Empty_Middle {Middle}
    - open= Empty_Bottom {Bottom}
    item:
      # Turn page
      '0':
        material: PAPER
        customdata: 31001
        name: "#e78b8b上一页"
        commands:
        - "open= Main_1_Top"
        - "sound= UI_BUTTON_CLICK"


  Main_1_Top:
    perm: default
    rows: 5
    title: Example
    commands-on-open:
    - open= Empty_Middle {Middle}
    - open= Empty_Bottom {Bottom}
    item:
    # turn page
      '8':
        material: PAPER
        customdata: 31001
        name: "#e78b8b下一页"
        commands:
        - "open= Main_2_Top"
        - "sound= UI_BUTTON_CLICK"


  Empty_Middle:
    perm: default
    rows: 3
    title: Example
    item:
      '0':
        material: AIR

  Empty_Bottom:
    perm: default
    rows: 1
    title: Example
    item:
      '0':
        material: AIR
```


https://github.com/user-attachments/assets/ebb33594-a82f-4559-9981-a59ffff0ec39

