### PR TITLE
Added support for correct custom command registering

### DIFF
--- a/src/me/rockyhawk/commandpanels/Context.java
+++ b/src/me/rockyhawk/commandpanels/Context.java
@@ -201,9 +201,6 @@ public class Context {
         if(configHandler.isTrue("config.refresh-panels")){
             Bukkit.getServer().getPluginManager().registerEvents(new PanelRefresher(this), plugin);
         }
-        if(configHandler.isTrue("config.custom-commands")){
-            Bukkit.getServer().getPluginManager().registerEvents(openCommands, plugin);
-        }
         if(configHandler.isTrue("config.hotbar-items")){
             Bukkit.getServer().getPluginManager().registerEvents(new HotbarEvents(this), plugin);
         }

--- a/src/me/rockyhawk/commandpanels/commands/ReloadCommand.java
+++ b/src/me/rockyhawk/commandpanels/commands/ReloadCommand.java
@@ -53,11 +53,6 @@ public class ReloadCommand implements CommandExecutor {
                     // reloadHotbarSlots
                     ctx.hotbar.reloadHotbarSlots();
 
-                    // register custom commands
-                    if (ctx.configHandler.isTrue("config.auto-register-commands")) {
-                        ctx.openCommands.registerCommands();
-                    }
-
                     // send success message
                     sender.sendMessage(ctx.text.colour(ctx.tag + ctx.configHandler.config.getString("config.format.reload")));
                 });
@@ -76,6 +71,11 @@ public class ReloadCommand implements CommandExecutor {
         //load panel files from panels folder
         fileNamesFromDirectory(new File(ctx.plugin.getDataFolder() + File.separator + "panels"));
         ctx.tag = ctx.text.colour(ctx.configHandler.config.getString("config.format.tag")) + " ";
+
+        Bukkit.getScheduler().runTask(ctx.plugin, () -> {
+            // register custom commands
+            ctx.openCommands.registerCommands();
+        });
     }
 
     //look through all files in all folders

--- a/src/me/rockyhawk/commandpanels/commands/opencommands/BaseCommandPanel.java
+++ b/src/me/rockyhawk/commandpanels/commands/opencommands/BaseCommandPanel.java
@@ -1,0 +1,62 @@
+package me.rockyhawk.commandpanels.commands.opencommands;
+
+import me.rockyhawk.commandpanels.Context;
+import me.rockyhawk.commandpanels.api.Panel;
+import me.rockyhawk.commandpanels.manager.session.PanelPosition;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class BaseCommandPanel extends Command {
+
+    private final Context ctx;
+    private final Panel panel;
+
+    public BaseCommandPanel(Context ctx, Panel panel, String name, List<String> aliases) {
+        super(name);
+        this.ctx = ctx;
+        this.panel = panel;
+        setAliases(aliases);
+    }
+
+    @Override
+    public boolean execute(@NotNull CommandSender commandSender, @NotNull String s, @NotNull String[] strings) {
+        if (!(commandSender instanceof Player)) {
+            commandSender.sendMessage("This command can only be used by players.");
+            return true;
+        }
+
+        Player player = (Player) commandSender;
+
+        if (strings.length == 0) {
+            panel.copy().open(player, PanelPosition.Top);
+            return true;
+        }
+
+        List<String> args = Arrays.asList(strings);
+        List<String[]> placeholders = new ArrayList<>();
+        String[] phEnds = ctx.placeholders.getPlaceholderEnds(panel,true);
+
+        for(int i = 0; i < args.size(); i++){
+            if(args.get(i).startsWith(phEnds[0])){
+                placeholders.add(new String[]{args.get(i).replace(phEnds[0],"").replace(phEnds[1],""), args.get(i+1)});
+                i++;
+            }else if(!args.get(i).equals(args.get(i+1))){
+                return false;
+            }
+        }
+
+        Panel openPanel = panel.copy();
+        for(String[] placeholder : placeholders){
+            openPanel.placeholders.addPlaceholder(placeholder[0],placeholder[1]);
+        }
+
+        openPanel.open(player,PanelPosition.Top);
+        return true;
+    }
+}

--- a/src/me/rockyhawk/commandpanels/commands/opencommands/OpenCommands.java
+++ b/src/me/rockyhawk/commandpanels/commands/opencommands/OpenCommands.java
@@ -1,120 +1,95 @@
 package me.rockyhawk.commandpanels.commands.opencommands;
 
+import com.google.common.collect.Maps;
 import me.rockyhawk.commandpanels.Context;
 import me.rockyhawk.commandpanels.api.Panel;
 import me.rockyhawk.commandpanels.manager.session.PanelPosition;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Server;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandMap;
+import org.bukkit.command.SimpleCommandMap;
 import org.bukkit.configuration.file.YamlConfiguration;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
-public class OpenCommands implements Listener {
-    Context ctx;
+public class OpenCommands {
+
+    private final Context ctx;
+    private final Map<String, Command> commands = Maps.newHashMap();
+    private final Map<String, Command> knownCommands = getKnownCommands();
+    private final CommandMap commandMap = getCommandMap();
+
+    private Map<String, Command> getKnownCommands() {
+        try {
+            Field knownCommandsField = SimpleCommandMap.class.getDeclaredField("knownCommands");
+            knownCommandsField.setAccessible(true);
+            return (Map<String, Command>) knownCommandsField.get(getCommandMap());
+        } catch (Exception e) {
+            throw new RuntimeException("Could not get known commands", e);
+        }
+    }
+
     public OpenCommands(Context pl) {
         this.ctx = pl;
     }
 
-    // For custom commands that are used to open panels
-    @EventHandler
-    public void PlayerCommand(PlayerCommandPreprocessEvent e) {
+    private void unloadCommands() {
+        commands.forEach((commandName, command) -> unregisterCommand(command));
+    }
+
+    public void unregisterCommand(Command command) {
         try {
-            for (Panel panel : ctx.plugin.panelList) {
-                if (panel.getConfig().contains("commands")) {
-                    List<String> panelCommands = panel.getConfig().getStringList("commands");
-                    for(String cmd : panelCommands){
-                        if(cmd.equalsIgnoreCase(e.getMessage().replace("/", ""))){
-                            e.setCancelled(true);
-                            panel.copy().open(e.getPlayer(), PanelPosition.Top);
-                            return;
-                        }
+            command.getAliases().forEach(knownCommands::remove);
+            knownCommands.remove(command.getName());
+            command.unregister(commandMap);
+        } catch (Exception ignored) {}
+    }
 
-                        boolean correctCommand = true;
-                        ArrayList<String[]> placeholders = new ArrayList<>(); //should read placeholder,argument
-                        String[] phEnds = ctx.placeholders.getPlaceholderEnds(panel,true); //start and end of placeholder
-                        String[] command = cmd.split("\\s");
-                        String[] message = e.getMessage().replace("/", "").split("\\s"); //command split into args
-
-                        if(command.length != message.length){
-                            continue;
-                        }
-
-                        for(int i = 0; i < cmd.split("\\s").length; i++){
-                            if(command[i].startsWith(phEnds[0])){
-                                placeholders.add(new String[]{command[i].replace(phEnds[0],"").replace(phEnds[1],""), message[i]});
-                            }else if(!command[i].equals(message[i])){
-                                correctCommand = false;
-                            }
-                        }
-
-                        if(correctCommand){
-                            e.setCancelled(true);
-                            Panel openPanel = panel.copy();
-                            for(String[] placeholder : placeholders){
-                                openPanel.placeholders.addPlaceholder(placeholder[0],placeholder[1]);
-                            }
-                            openPanel.open(e.getPlayer(),PanelPosition.Top);
-                            return;
-                        }
-                    }
-                }
+    private void loadCommands() {
+        ctx.plugin.panelList.forEach(panel -> {
+            if (!panel.getConfig().contains("commands")) {
+                return;
             }
-        }catch(NullPointerException exc){
-            //this is placed to prevent null exceptions if the commandpanels reload command has file changes
-            ctx.debug.send(exc,e.getPlayer(), ctx);
+
+            List<String> panelCommands = panel.getConfig().getStringList("commands");
+            if (panelCommands.isEmpty()) {
+                return;
+            }
+
+            String commandName = panelCommands.remove(0);
+            Command command = new BaseCommandPanel(ctx, panel, commandName, panelCommands);
+
+            commandMap.register(command.getName(), "commandpanels", command);
+            commands.put(command.getName(), command);
+        });
+    }
+
+    private CommandMap getCommandMap() {
+        try {
+            final Class<? extends Server> serverClass = Bukkit.getServer().getClass();
+            final Field commandMapField = serverClass.getDeclaredField("commandMap");
+            commandMapField.setAccessible(true);
+            return (CommandMap) commandMapField.get(Bukkit.getServer());
+        } catch (Exception e) {
+            throw new RuntimeException("Unable to get command map", e);
         }
     }
 
-    //this will require a server restart for new commands
+
     public void registerCommands(){
-        File commandsLoc = new File("commands.yml");
-        YamlConfiguration cmdCF;
-        try {
-            cmdCF = YamlConfiguration.loadConfiguration(commandsLoc);
-        }catch(Exception e){
-            //could not access the commands.yml file
-            ctx.debug.send(e,null, ctx);
-            return;
-        }
-
-        //remove old commandpanels commands
-        for(String existingCommands : cmdCF.getConfigurationSection("aliases").getKeys(false)){
-            try {
-                if (cmdCF.getStringList("aliases." + existingCommands).get(0).equals("commandpanel")) {
-                    cmdCF.set("aliases." + existingCommands, null);
-                }
-            }catch(Exception ignore){}
-        }
-
-        //make the command 'commandpanels' to identify it
-        ArrayList<String> temp = new ArrayList<>();
-        temp.add("commandpanel");
-
-        for (Panel panel : ctx.plugin.panelList) {
-            if(panel.getConfig().contains("panelType")){
-                if(panel.getConfig().getStringList("panelType").contains("nocommandregister")){
-                    continue;
-                }
-            }
-
-            if(panel.getConfig().contains("commands")){
-                List<String> panelCommands = panel.getConfig().getStringList("commands");
-                for(String command : panelCommands){
-                    cmdCF.set("aliases." + command.split("\\s")[0],temp);
-                }
-            }
-        }
-
-        try {
-            cmdCF.save(commandsLoc);
-        } catch (IOException var10) {
-            Bukkit.getConsoleSender().sendMessage("[CommandPanels]" + ChatColor.RED + " WARNING: Could not register custom commands!");
-        }
+        unloadCommands();
+        loadCommands();
+        Bukkit.getOnlinePlayers().forEach(Player::updateCommands);
     }
 }


### PR DESCRIPTION
Old command system wasn't using minecraft commands but was relying on the PlayerCommandPreprocessEvent.
This new system is also O(1) since it uses an hashmap, the old was n(total panels) * (each subcommand)
The placeholder subcommand should work but it should be tested.