### PR TITLE
Skript support, Open requirements, Bungeetag bug

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -87,6 +87,11 @@
       <option name="url" value="https://hub.spigotmc.org/nexus/content/repositories/snapshots/" />
     </remote-repository>
     <remote-repository>
+      <option name="id" value="skript-releases" />
+      <option name="name" value="Skript Repository" />
+      <option name="url" value="https://repo.skriptlang.org/releases" />
+    </remote-repository>
+    <remote-repository>
       <option name="id" value="jeff-media-public" />
       <option name="name" value="jeff-media-public" />
       <option name="url" value="https://repo.jeff-media.com/public/" />

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,13 @@
             <id>opencollab-snapshot</id>
             <url>https://repo.opencollab.dev/main/</url>
         </repository>
+        
+        <!-- Skript Repository -->
+        <repository>
+            <id>skript-releases</id>
+            <name>Skript Repository</name>
+            <url>https://repo.skriptlang.org/releases</url>
+        </repository>
     </repositories>
 
     <dependencies>
@@ -247,6 +254,14 @@
             <groupId>org.geysermc.floodgate</groupId>
             <artifactId>api</artifactId>
             <version>2.2.2-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        
+        <!-- Skript -->
+        <dependency>
+            <groupId>com.github.SkriptLang</groupId>
+            <artifactId>Skript</artifactId>
+            <version>2.8.5</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/resource/config.yml
+++ b/resource/config.yml
@@ -16,6 +16,9 @@ config:
   disabled-world-message: true
   panel-snooper: false
   enable-import-command: false
+  autosave:
+    enabled: false
+    interval: '30m'  # Supports: s (seconds), m (minutes), h (hours), d (days)
   format:
     tag: '&6[&bCommandPanels&6]'
     perms: '&cNo permission.'

--- a/resource/plugin.yml
+++ b/resource/plugin.yml
@@ -5,7 +5,7 @@ author: RockyHawk
 api-version: '1.13'
 folia-supported: true
 description: Fully Custom GUIs. Make your Server Professional.
-softdepend: [Essentials, PlaceholderAPI, Vault, HeadDatabase, TokenManager, VotingPlugin, MMOItems, ChestSort, floodgate]
+softdepend: [Essentials, PlaceholderAPI, Vault, HeadDatabase, TokenManager, VotingPlugin, MMOItems, ChestSort, floodgate, Skript]
 commands:
    commandpanel:
       description: Open a command panel.

--- a/src/me/rockyhawk/commandpanels/CommandPanels.java
+++ b/src/me/rockyhawk/commandpanels/CommandPanels.java
@@ -48,6 +48,11 @@ public class CommandPanels extends JavaPlugin{
         }
 
         try {
+            //stop autosave system
+            if (ctx.autoSave != null) {
+                ctx.autoSave.stop();
+            }
+            
             //close all the panels
             if (ctx.openPanels != null && ctx.openPanels.openPanels != null) {
                 for(String name : ctx.openPanels.openPanels.keySet()){

--- a/src/me/rockyhawk/commandpanels/Context.java
+++ b/src/me/rockyhawk/commandpanels/Context.java
@@ -28,6 +28,7 @@ import me.rockyhawk.commandpanels.builder.floodgate.OpenFloodgateGUI;
 import me.rockyhawk.commandpanels.generate.GenerateCommand;
 import me.rockyhawk.commandpanels.generate.GenUtils;
 import me.rockyhawk.commandpanels.generate.GenTabComplete;
+import me.rockyhawk.commandpanels.manager.autosave.AutoSaveManager;
 import me.rockyhawk.commandpanels.manager.refresh.PanelRefresher;
 import me.rockyhawk.commandpanels.manager.PlayerJoinEvent;
 import me.rockyhawk.commandpanels.interaction.input.PlayerInputUtils;
@@ -95,6 +96,7 @@ public class Context {
     public ItemStackSerializer itemSerializer;
     public PlayerInputUtils inputUtils;
     public SchedulerAdapter scheduler;
+    public AutoSaveManager autoSave;
 
     public Context(CommandPanels pl) {
         plugin = pl;
@@ -149,6 +151,9 @@ public class Context {
         generator = new GenUtils(this);
         itemSerializer = new ItemStackSerializer(this);
         inputUtils = new PlayerInputUtils(this);
+
+        // Initialize autosave manager
+        autoSave = new AutoSaveManager(this);
 
         //setup class files
         setupEconomy();

--- a/src/me/rockyhawk/commandpanels/configuration/ConfigHandler.java
+++ b/src/me/rockyhawk/commandpanels/configuration/ConfigHandler.java
@@ -73,6 +73,11 @@ public class ConfigHandler {
             }
         }
         saveExamplePanels();
+        
+        // Initialize autosave system after config is loaded
+        if (ctx.autoSave != null) {
+            ctx.autoSave.initialize();
+        }
     }
 
     private void saveExamplePanels(){

--- a/src/me/rockyhawk/commandpanels/interaction/commands/CommandRunner.java
+++ b/src/me/rockyhawk/commandpanels/interaction/commands/CommandRunner.java
@@ -104,6 +104,7 @@ public class CommandRunner {
         tags.add(new RefreshTag());
         tags.add(new SetCustomDataTag());
         tags.add(new SetItemTag());
+        tags.add(new SkriptTag());
         tags.add(new SoundTag());
         tags.add(new TeleportTag());
         tags.add(new TitleTag());

--- a/src/me/rockyhawk/commandpanels/interaction/commands/tags/BungeeTag.java
+++ b/src/me/rockyhawk/commandpanels/interaction/commands/tags/BungeeTag.java
@@ -12,6 +12,11 @@ public class BungeeTag implements TagResolver {
 
     @Override
     public boolean handle(Context ctx, Panel panel, PanelPosition pos, Player player, String command) {
+        // Only handle server= and force-server= commands
+        if (!command.startsWith("server=") && !command.startsWith("force-server=")) {
+            return false;
+        }
+        
         String[] args = ctx.text.attachPlaceholders(panel, pos, player, command).split("\\s+");
 
         if (args.length <= 1) {

--- a/src/me/rockyhawk/commandpanels/interaction/commands/tags/SkriptTag.java
+++ b/src/me/rockyhawk/commandpanels/interaction/commands/tags/SkriptTag.java
@@ -1,0 +1,111 @@
+package me.rockyhawk.commandpanels.interaction.commands.tags;
+
+import me.rockyhawk.commandpanels.Context;
+import me.rockyhawk.commandpanels.api.Panel;
+import me.rockyhawk.commandpanels.interaction.commands.TagResolver;
+import me.rockyhawk.commandpanels.manager.session.PanelPosition;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Method;
+import java.util.Arrays;
+
+public class SkriptTag implements TagResolver {
+
+    @Override
+    public boolean handle(Context ctx, Panel panel, PanelPosition pos, Player player, String command) {
+        if (!command.startsWith("skript=")) return false;
+        
+        String[] args = ctx.text.attachPlaceholders(panel, pos, player, command).split("\\s+");
+        args = Arrays.copyOfRange(args, 1, args.length); // Remove first element from args
+        
+        if (args.length == 0) {
+            player.sendMessage(ctx.tag + ctx.text.colour(ctx.configHandler.config.getString("config.format.error") + " skript=: No Skript command provided!"));
+            return true;
+        }
+        
+        // Check if Skript plugin is enabled
+        if (!Bukkit.getPluginManager().isPluginEnabled("Skript")) {
+            player.sendMessage(ctx.tag + ctx.text.colour(ctx.configHandler.config.getString("config.format.error") + " skript=: Skript plugin is not loaded!"));
+            return true;
+        }
+        
+        try {
+            String commandName = args[0];
+            String[] commandArgs = args.length > 1 ? Arrays.copyOfRange(args, 1, args.length) : new String[0];
+            
+            executeSkriptCommand(player, commandName, commandArgs);
+            
+        } catch (Exception ex) {
+            player.sendMessage(ctx.tag + ctx.text.colour(ctx.configHandler.config.getString("config.format.error") + " skript=: Error executing Skript command!"));
+            ctx.debug.send(ex, player, ctx);
+        }
+        
+        return true;
+    }
+    
+    // Method to execute a Skript command by name
+    private void executeSkriptCommand(Player player, String commandName, String[] args) {
+        try {
+            // Try to get the Skript command classes
+            Class<?> commandsClass = Class.forName("ch.njol.skript.command.Commands");
+            Class<?> scriptCommandClass = Class.forName("ch.njol.skript.command.ScriptCommand");
+            
+            // Get the getCommands method
+            Method getCommandsMethod = commandsClass.getMethod("getCommands");
+            Object commands = getCommandsMethod.invoke(null);
+            
+            // Check if the returned object is iterable
+            if (commands instanceof Iterable) {
+                @SuppressWarnings("unchecked")
+                Iterable<Object> commandList = (Iterable<Object>) commands;
+                
+                // Find the command in Skript's registered commands
+                for (Object command : commandList) {
+                    if (command.getClass().equals(scriptCommandClass)) {
+                        Method getNameMethod = command.getClass().getMethod("getName");
+                        String scriptCommandName = (String) getNameMethod.invoke(command);
+                        
+                        if (scriptCommandName.equalsIgnoreCase(commandName)) {
+                            // Execute the command for the player with given arguments
+                            Method executeMethod = command.getClass().getMethod("execute", Player.class, String.class, String[].class);
+                            executeMethod.invoke(command, player, commandName, args);
+                            return;
+                        }
+                    }
+                }
+            }
+            
+            player.sendMessage("Command '" + commandName + "' not found in Skript!");
+            
+        } catch (Exception e) {
+            // If the direct approach fails, try alternative method using functions
+            try {
+                executeSkriptFunction(commandName, new Object[]{player});
+            } catch (Exception ex) {
+                // Fallback: dispatch as regular command with skript prefix
+                String fullCommand = commandName;
+                if (args.length > 0) {
+                    fullCommand += " " + String.join(" ", args);
+                }
+                
+                // Try to execute as a regular command (in case it's a custom Skript command)
+                Bukkit.dispatchCommand(player, fullCommand);
+            }
+        }
+    }
+    
+    // Execute a Skript function as an alternative approach
+    private void executeSkriptFunction(String functionName, Object[] params) throws Exception {
+        Class<?> functionsClass = Class.forName("ch.njol.skript.lang.function.Functions");
+        Class<?> functionClass = Class.forName("ch.njol.skript.lang.function.Function");
+        
+        Method getFunctionMethod = functionsClass.getMethod("getFunction", String.class);
+        Object function = getFunctionMethod.invoke(null, functionName);
+        
+        if (function != null) {
+            Method executeMethod = functionClass.getMethod("execute", Object[].class);
+            executeMethod.invoke(function, new Object[]{params});
+        }
+    }
+} 

--- a/src/me/rockyhawk/commandpanels/manager/autosave/AutoSaveManager.java
+++ b/src/me/rockyhawk/commandpanels/manager/autosave/AutoSaveManager.java
@@ -1,0 +1,154 @@
+package me.rockyhawk.commandpanels.manager.autosave;
+
+import me.rockyhawk.commandpanels.Context;
+import org.bukkit.Bukkit;
+
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class AutoSaveManager {
+    private final Context ctx;
+    private int taskId = -1;
+    private boolean enabled = false;
+    private long intervalTicks = 0;
+
+    public AutoSaveManager(Context ctx) {
+        this.ctx = ctx;
+    }
+
+    /**
+     * Initialize the autosave system based on config settings
+     */
+    public void initialize() {
+        // Stop any existing task
+        stop();
+        
+        // Check if autosave is enabled
+        enabled = ctx.configHandler.config.getBoolean("config.autosave.enabled", false);
+        if (!enabled) {
+            return;
+        }
+
+        // Parse the interval
+        String intervalString = ctx.configHandler.config.getString("config.autosave.interval", "30m");
+        intervalTicks = parseIntervalToTicks(intervalString);
+        
+        if (intervalTicks <= 0) {
+            Bukkit.getLogger().warning("[CommandPanels] Invalid autosave interval: " + intervalString + ". Autosave disabled.");
+            enabled = false;
+            return;
+        }
+
+        // Start the autosave task
+        start();
+        
+        Bukkit.getLogger().info("[CommandPanels] Autosave enabled with interval: " + intervalString + " (" + intervalTicks + " ticks)");
+    }
+
+    /**
+     * Start the autosave task
+     */
+    private void start() {
+        if (!enabled || intervalTicks <= 0) {
+            return;
+        }
+
+        taskId = ctx.scheduler.runTaskTimerAsynchronously(() -> {
+            try {
+                // Save data files (not inventory files as requested)
+                if (ctx.panelData != null) {
+                    ctx.panelData.saveDataFile();
+                    Bukkit.getLogger().info("[CommandPanels] Autosave: Data file saved successfully");
+                }
+            } catch (Exception e) {
+                Bukkit.getLogger().severe("[CommandPanels] Autosave failed: " + e.getMessage());
+                e.printStackTrace();
+            }
+        }, intervalTicks, intervalTicks);
+    }
+
+    /**
+     * Stop the autosave task
+     */
+    public void stop() {
+        if (taskId != -1) {
+            ctx.scheduler.cancelTask(taskId);
+            taskId = -1;
+        }
+    }
+
+    /**
+     * Parse interval string to ticks
+     * Supports: s (seconds), m (minutes), h (hours), d (days)
+     * Examples: "30s", "5m", "2h", "1d"
+     */
+    private long parseIntervalToTicks(String interval) {
+        if (interval == null || interval.trim().isEmpty()) {
+            return 0;
+        }
+
+        // Pattern to match number followed by time unit
+        Pattern pattern = Pattern.compile("^(\\d+)([smhd])$", Pattern.CASE_INSENSITIVE);
+        Matcher matcher = pattern.matcher(interval.trim().toLowerCase());
+
+        if (!matcher.matches()) {
+            return 0;
+        }
+
+        long amount = Long.parseLong(matcher.group(1));
+        String unit = matcher.group(2);
+
+        long seconds;
+        switch (unit) {
+            case "s":
+                seconds = amount;
+                break;
+            case "m":
+                seconds = amount * 60;
+                break;
+            case "h":
+                seconds = amount * 60 * 60;
+                break;
+            case "d":
+                seconds = amount * 60 * 60 * 24;
+                break;
+            default:
+                return 0;
+        }
+
+        // Convert seconds to ticks (20 ticks = 1 second)
+        return seconds * 20;
+    }
+
+    /**
+     * Check if autosave is currently enabled
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Get the current interval in ticks
+     */
+    public long getIntervalTicks() {
+        return intervalTicks;
+    }
+
+    /**
+     * Manually trigger a save (useful for commands or other triggers)
+     */
+    public void forceSave() {
+        ctx.scheduler.runTaskAsynchronously(() -> {
+            try {
+                if (ctx.panelData != null) {
+                    ctx.panelData.saveDataFile();
+                    Bukkit.getLogger().info("[CommandPanels] Manual save: Data file saved successfully");
+                }
+            } catch (Exception e) {
+                Bukkit.getLogger().severe("[CommandPanels] Manual save failed: " + e.getMessage());
+                e.printStackTrace();
+            }
+        });
+    }
+} 

--- a/src/me/rockyhawk/commandpanels/manager/open/OpenPanel.java
+++ b/src/me/rockyhawk/commandpanels/manager/open/OpenPanel.java
@@ -18,6 +18,7 @@ public class OpenPanel {
     private final PanelCommandExecutor commandExecutor;
     private final SoundHandler soundPlayer;
     private final PreLoadCommands preloader;
+    private final OpenRequirements requirementsValidator;
 
     public OpenPanel(Context ctx) {
         this.ctx = ctx;
@@ -25,6 +26,7 @@ public class OpenPanel {
         this.commandExecutor = new PanelCommandExecutor(ctx);
         this.soundPlayer = new SoundHandler(ctx);
         this.preloader = new PreLoadCommands(ctx);
+        this.requirementsValidator = new OpenRequirements(ctx);
     }
 
     public void open(CommandSender sender, Player p, Panel panel, PanelPosition position) {
@@ -41,6 +43,13 @@ public class OpenPanel {
         boolean openForOtherUser = !(sender instanceof Player && sender == p);
 
         if (!permission.hasPermission(sender, p, panel, position, openForOtherUser)) return;
+
+        // Check open requirements before allowing panel to open
+        if (!requirementsValidator.canOpenPanel(panel, p, position)) {
+            String failMessage = requirementsValidator.getOpenRequirementFailMessage(panel);
+            sender.sendMessage(ctx.text.colour(ctx.tag + failMessage));
+            return;
+        }
 
         if (position != PanelPosition.Top && !ctx.openPanels.hasPanelOpen(p.getName(), PanelPosition.Top)) {
             sender.sendMessage(ctx.text.colour(ctx.tag + ChatColor.RED + "Cannot open a panel without a panel at the top already."));

--- a/src/me/rockyhawk/commandpanels/manager/open/OpenRequirements.java
+++ b/src/me/rockyhawk/commandpanels/manager/open/OpenRequirements.java
@@ -1,0 +1,89 @@
+package me.rockyhawk.commandpanels.manager.open;
+
+import me.rockyhawk.commandpanels.Context;
+import me.rockyhawk.commandpanels.api.Panel;
+import me.rockyhawk.commandpanels.manager.session.PanelPosition;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+
+public class OpenRequirements {
+    private final Context ctx;
+
+    public OpenRequirements(Context ctx) {
+        this.ctx = ctx;
+    }
+
+    // Store the last matched section for fail message purposes
+    private String lastMatchedSectionForFailMessage = "";
+
+    /**
+     * Validates if a player can open a panel based on open-requirements section
+     * Returns true if player can open the panel, false otherwise
+     */
+    public boolean canOpenPanel(Panel panel, Player player, PanelPosition position) {
+        ConfigurationSection config = panel.getConfig();
+        
+        // If no open-requirements section exists, allow opening (default behavior)
+        if (!config.contains("open-requirements")) {
+            return true;
+        }
+        
+        ConfigurationSection openRequirements = config.getConfigurationSection("open-requirements");
+        if (openRequirements == null) {
+            return true;
+        }
+        
+        // Default can-open value is false as requested
+        boolean defaultCanOpen = openRequirements.getBoolean("can-open", false);
+        
+        // Use the existing hasSection method - it will automatically skip non-has keys like can-open and message
+        String matchedSection = ctx.has.hasSection(panel, position, openRequirements, player);
+        boolean hasMatch = !matchedSection.isEmpty();
+        
+        if (hasMatch) {
+            // Extract the section name from the result (remove the leading dot)
+            String sectionName = matchedSection.startsWith(".") ? matchedSection.substring(1) : matchedSection;
+            this.lastMatchedSectionForFailMessage = sectionName;
+            
+            // Get the can-open value from the matched section
+            boolean sectionCanOpen = openRequirements.getConfigurationSection(sectionName).getBoolean("can-open", false);
+            return sectionCanOpen;
+        }
+        
+        // No sections matched, clear the stored section and return default
+        this.lastMatchedSectionForFailMessage = "";
+        return defaultCanOpen;
+    }
+    
+    /**
+     * Gets the error message for when a player cannot open a panel
+     */
+    public String getOpenRequirementFailMessage(Panel panel) {
+        ConfigurationSection config = panel.getConfig();
+        
+        // Check if we have a matched section with a custom message
+        if (!lastMatchedSectionForFailMessage.isEmpty()) {
+            String sectionPath = "open-requirements." + lastMatchedSectionForFailMessage;
+            
+            // Check if this section has a message
+            if (config.contains(sectionPath + ".message")) {
+                String sectionMessage = config.getString(sectionPath + ".message");
+                return sectionMessage;
+            }
+        }
+        
+        // Fall back to default message
+        if (config.contains("open-requirements.message")) {
+            String defaultMessage = config.getString("open-requirements.message");
+            return defaultMessage;
+        }
+        
+        // Use the same format as permission errors
+        String customMessage = panel.getConfig().getString("custom-messages.perms");
+        if (customMessage != null) {
+            return customMessage;
+        }
+        
+        return ctx.configHandler.config.getString("config.format.perms");
+    }
+} 


### PR DESCRIPTION
**Skript support**
Direct skript support so you dont have to hope sudo= works.
```
item:
  '0':
    material: COMMAND_BLOCK
    name: '&6Execute Skript Command'
    lore:
      - '&7Click to run a Skript command'
      - '&eExample: skript= heal %cp-player-name%'
    commands:
      - 'skript= heal %cp-player-name%'
  '1':
    material: REDSTONE
    name: '&cExecute Skript Function'
    lore:
      - '&7Click to execute a Skript function'
      - '&eExample: skript= myfunction arg1 arg2'
    commands:
      - 'skript= myfunction %cp-player-name% welcome'
  '2':
    material: PAPER
    name: '&aRun Custom Skript'
    lore:
      - '&7Click to run custom Skript commands'
      - '&eYou can run any Skript command registered'
      - '&ein your .sk files'
    commands:
      - 'skript= customcommand %cp-player-name%'
      - 'msg= &aSkript command executed!'
```

**Open requirements**
Open requirements will check before the panel can open using has sections. You can set messages for each step to allow easier messaging to the players.
```
open-requirements:
  can-open: false                    # Default behavior
  message: '&cDefault deny message'  # Default message
  has0:
    value0: '%cp-player-name%'
    compare0: 'TinyTank800'
    can-open: false                  # Deny specific player
    message: '&eSpecific deny message for player!'
  has1:
    value0: '%cp-player-name% HASPERM'
    compare0: 'admin.permission'
    can-open: true                   # Allow if has permission
    message: '&cNo admin permission!' # Only shown if permission missing
```

**Bungeetag**
Bungeetag was not checking for its tags so it took over all tags.