### PR TITLE
Bundle hide attributes fix. Maybe shulker?

### DIFF
--- a/src/me/rockyhawk/commandpanels/builder/inventory/items/utils/NameHandler.java
+++ b/src/me/rockyhawk/commandpanels/builder/inventory/items/utils/NameHandler.java
@@ -34,7 +34,10 @@ public class NameHandler {
                             DataComponentTypes.TRIM,
                             DataComponentTypes.BANNER_PATTERNS,
                             DataComponentTypes.FIREWORKS,
-                            DataComponentTypes.JUKEBOX_PLAYABLE
+                            DataComponentTypes.JUKEBOX_PLAYABLE,
+                            DataComponentTypes.BUNDLE_CONTENTS,
+                            DataComponentTypes.CONTAINER,
+                            DataComponentTypes.CONTAINER_LOOT
                     ).build();
             item.setData(DataComponentTypes.TOOLTIP_DISPLAY, hideAttributes);
         }


### PR DESCRIPTION
Fixed bundles showing contents with hide attributes.
Maybe shulkers "empty" tag as well? Tested on modded client with shulker tooltips and it was still showing but cant find any other Data type relating to that sort of thing?