### PR TITLE
Do not parse colors before executing a command

### DIFF
--- a/src/me/rockyhawk/commandpanels/interaction/commands/CommandRunner.java
+++ b/src/me/rockyhawk/commandpanels/interaction/commands/CommandRunner.java
@@ -85,7 +85,7 @@ public class CommandRunner {
             String tag = parts[0];
 
             String args = (parts.length > 1) ? parts[1].trim() : "";
-            String argsParsed = ctx.text.parseTextToString(player, args);
+            String argsParsed = ctx.text.applyPlaceholders(player, args);
 
             if (resolver.isCorrectTag(tag)) {
                 resolver.handle(ctx, panel, player, args, argsParsed);


### PR DESCRIPTION
Otherwise, commands containing color codes (e.g. when passing user-specified text from dialog input as a command argument) will result malformed command string.