### PR TITLE
add Aurora integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,12 @@
             <url>https://jitpack.io</url>
         </repository>
 
+        <!-- Aurora -->
+        <repository>
+            <id>auroramc</id>
+            <url>https://repo.auroramc.gg/releases/</url>
+        </repository>
+
     </repositories>
 
     <dependencies>
@@ -182,6 +188,14 @@
             <groupId>com.github.MilkBowl</groupId>
             <artifactId>VaultAPI</artifactId>
             <version>1.7.1</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- Aurora -->
+        <dependency>
+            <groupId>gg.auroramc</groupId>
+            <artifactId>Aurora</artifactId>
+            <version>2.5.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/resource/paper-plugin.yml
+++ b/resource/paper-plugin.yml
@@ -23,3 +23,5 @@ dependencies:
          required: false
       Vault:
          required: false
+      Aurora:
+         required: false

--- a/src/me/rockyhawk/commandpanels/builder/inventory/items/ItemBuilder.java
+++ b/src/me/rockyhawk/commandpanels/builder/inventory/items/ItemBuilder.java
@@ -103,6 +103,7 @@ public class ItemBuilder {
         this.materialComponents.add(new ItemsAdderComponent());
         this.materialComponents.add(new MMOItemsComponent());
         this.materialComponents.add(new HeadDatabaseComponent());
+        this.materialComponents.add(new AuroraComponent());
 
         // Add Item Components
         this.itemComponents.add(new EnchantedComponent());

--- a/src/me/rockyhawk/commandpanels/builder/inventory/items/materialcomponents/AuroraComponent.java
+++ b/src/me/rockyhawk/commandpanels/builder/inventory/items/materialcomponents/AuroraComponent.java
@@ -1,0 +1,21 @@
+package me.rockyhawk.commandpanels.builder.inventory.items.materialcomponents;
+
+import gg.auroramc.aurora.api.AuroraAPI;
+import gg.auroramc.aurora.api.item.TypeId;
+import me.rockyhawk.commandpanels.Context;
+import me.rockyhawk.commandpanels.builder.inventory.items.MaterialComponent;
+import me.rockyhawk.commandpanels.session.inventory.PanelItem;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public class AuroraComponent implements MaterialComponent {
+    @Override
+    public boolean isCorrectTag(String tag) {
+        return tag.toLowerCase().startsWith("[aurora]");
+    }
+
+    @Override
+    public ItemStack createItem(Context ctx, String itemID, Player player, PanelItem item) {
+        return AuroraAPI.getItemManager().resolveItem(TypeId.fromString(itemID));
+    }
+}


### PR DESCRIPTION
This PR adds integration with **[AuroraNetworkStudios/Aurora](https://github.com/AuroraNetworkStudios/Aurora)**.

Aurora is a "core" plugin for all projects coming from **AuroraNetworkStudios** - e.g. **AuroraQuests**, **AuroraCrafting**, or **AuroraLevels**.

It supports a few custom item plugins but also comes with it's own item registry which I personally use a lot.

Usage:
```yml
material: "[aurora] aurora:raw_tuna"
```
```yml
material: "[aurora] crackshot:item_id"
```

Reference: https://docs.auroramc.gg/aurora/item-config