### PR TITLE
add raw components support

### DIFF
--- a/src/me/rockyhawk/commandpanels/builder/inventory/items/ItemBuilder.java
+++ b/src/me/rockyhawk/commandpanels/builder/inventory/items/ItemBuilder.java
@@ -105,6 +105,8 @@ public class ItemBuilder {
         this.materialComponents.add(new HeadDatabaseComponent());
 
         // Add Item Components
+        // raw components must be applied first - otherwise, all previously set data would be reset
+        this.itemComponents.add(new ComponentsComponent());
         this.itemComponents.add(new EnchantedComponent());
         this.itemComponents.add(new ItemModelComponent());
         this.itemComponents.add(new CustomModelDataComponent());

--- a/src/me/rockyhawk/commandpanels/builder/inventory/items/itemcomponents/ComponentsComponent.java
+++ b/src/me/rockyhawk/commandpanels/builder/inventory/items/itemcomponents/ComponentsComponent.java
@@ -1,0 +1,29 @@
+package me.rockyhawk.commandpanels.builder.inventory.items.itemcomponents;
+
+import me.rockyhawk.commandpanels.Context;
+import me.rockyhawk.commandpanels.builder.inventory.items.ItemComponent;
+import me.rockyhawk.commandpanels.session.inventory.PanelItem;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+// this tag replaces all components on an item (except for material and amount), therefore, is generally not advised to be used with non-vanilla material components (e.g., nexo, itemsadder)
+public class ComponentsComponent implements ItemComponent {
+
+    @Override
+    public ItemStack apply(Context ctx, ItemStack itemStack, Player player, PanelItem item) {
+        if (item.components() == null || item.components().isEmpty()) return itemStack;
+        // building components string
+        final StringBuilder componentsBuilder = new StringBuilder(itemStack.getType().key().asString() + "[");
+        item.components().forEach((component, value) -> {
+            componentsBuilder.append(component).append("=").append(value).append(",");
+        });
+        // removing trailing comma
+        componentsBuilder.deleteCharAt(componentsBuilder.length() - 1);
+        componentsBuilder.append("]");
+        // https://github.com/PaperMC/Paper/blob/main/paper-server/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+        // in case of malformed input, this method does not throw but fails with a non-catchable console error
+        // in case of failure, the original item stack is returned
+        return Bukkit.getUnsafe().modifyItemStack(itemStack, componentsBuilder.toString());
+    }
+}

--- a/src/me/rockyhawk/commandpanels/session/inventory/PanelItem.java
+++ b/src/me/rockyhawk/commandpanels/session/inventory/PanelItem.java
@@ -5,6 +5,9 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.event.inventory.ClickType;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 public record PanelItem(
         String id,
@@ -29,6 +32,7 @@ public record PanelItem(
         String potionColor,
         String potion,
         String tooltipStyle,
+        Map<String, String> components,
         List<String> banner,
         List<String> enchantments
 ) {
@@ -55,6 +59,7 @@ public record PanelItem(
             String potionColor,
             String potion,
             String tooltipStyle,
+            Map<String, String> components,
             List<String> banner,
             List<String> enchantments
     ) {
@@ -80,6 +85,7 @@ public record PanelItem(
         this.potionColor = potionColor;
         this.potion = potion;
         this.tooltipStyle = tooltipStyle;
+        this.components = components;
         this.banner = List.copyOf(banner);
         this.enchantments = List.copyOf(enchantments);
     }
@@ -108,7 +114,23 @@ public record PanelItem(
         String potionColor = section.getString("potion-color", null);
         String potion = section.getString("potion", null);
         String tooltipStyle = section.getString("tooltip-style", null);
-
+        Map<String, String> components = (section.getConfigurationSection("components") != null)
+                ? section.getConfigurationSection("components").getValues(false).entrySet().stream()
+                        // filtering out anything but strings, booleans and numbers; unfortunately, there's no easy way to convert e.g., map or configuration section to their raw representation
+                        .map(it -> {
+                            // values represented by a single string value (e.g., item_model) must be quoted
+                            // values represented by an array or an object (i.e., lore, custom_name) must not be quoted
+                            // this check is not comprehensive but should work in most cases
+                            if (it.getValue() instanceof String value)
+                                return Map.entry(it.getKey(), (!value.startsWith("{") && !value.startsWith("[")) ? ("\"" + value + "\"") : value);
+                            else if (it.getValue() instanceof Boolean || it.getValue() instanceof Number)
+                                return Map.entry(it.getKey(), it.getValue().toString());
+                            // anything else is considered invalid and should be skipped
+                            return null;
+                        })
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue))
+                : null;
         List<String> banner = section.getStringList("banner");
         List<String> enchanted = section.getStringList("enchantments");
 
@@ -135,6 +157,7 @@ public record PanelItem(
                 potionColor,
                 potion,
                 tooltipStyle,
+                components,
                 banner,
                 enchanted
         );


### PR DESCRIPTION
This PR adds a new `components` property to allow setting raw components on panel items. It does rely on `Unsafe#modifyItemStack(ItemStack, String)` method which should be more stable than NMS. Due to how this method works however, it is not feasible to *easily* support items coming from integrations such us Oraxen, Nexo, ItemsAdder, etc. You generally want to set raw components *only* on vanilla items. This should be stated in the docs.

Code comments should make this clear enough but I'm open to answer any questions.

**Example:**
```yml
claim_block:
  material: coal_block
  name: '<lang:item.firedot.claim_block>'
  lore:
  - '<gray><lang:item.firedot.claim_block.description>'
  components:
    minecraft:enchantment_glint_override: true
    minecraft:custom_name: '{ text: "Custom Item Name", color: "#FF0000" }'
    minecraft:max_stack_size: 14
```
Because `components` contents are applied first, other properties will override it.
In example above, `minecraft:custom_name` raw component is overridden by `name` property.

Raw components must be manually updated by end-user in case Mojang decides to change their format.