### PR TITLE
Add TokenManager support as a requirement tag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -205,6 +205,14 @@
             <scope>provided</scope>
         </dependency>
 
+        <!-- TokenManager API -->
+        <dependency>
+            <groupId>com.github.Realizedd</groupId>
+            <artifactId>TokenManager</artifactId>
+            <version>3.2.3</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!-- bstats -->
         <dependency>
             <groupId>org.bstats</groupId>

--- a/resource/paper-plugin.yml
+++ b/resource/paper-plugin.yml
@@ -23,6 +23,8 @@ dependencies:
          required: false
       Vault:
          required: false
+      TokenManager:
+         required: false
       CraftEngine:
          load: BEFORE
          required: false

--- a/src/me/rockyhawk/commandpanels/api/Registry.java
+++ b/src/me/rockyhawk/commandpanels/api/Registry.java
@@ -18,6 +18,7 @@ import me.rockyhawk.commandpanels.interaction.commands.CommandTagResolver;
 import me.rockyhawk.commandpanels.interaction.commands.RequirementTagResolver;
 import me.rockyhawk.commandpanels.interaction.commands.requirements.ConditionTag;
 import me.rockyhawk.commandpanels.interaction.commands.requirements.ItemTag;
+import me.rockyhawk.commandpanels.interaction.commands.requirements.TokenManagerTag;
 import me.rockyhawk.commandpanels.interaction.commands.requirements.VaultTag;
 import me.rockyhawk.commandpanels.interaction.commands.requirements.XpTag;
 import me.rockyhawk.commandpanels.interaction.commands.tags.ChatTag;
@@ -145,6 +146,7 @@ public final class Registry<T extends Registrable> implements Iterable<T> {
     public static final @NonNull Registry<RequirementTagResolver> REQUIREMENT_TAG_RESOLVERS = new Registry<>(List.of(
             new ConditionTag(),
             new VaultTag(),
+            new TokenManagerTag(),
             new ItemTag(),
             new me.rockyhawk.commandpanels.interaction.commands.requirements.DataTag(),
             new XpTag()

--- a/src/me/rockyhawk/commandpanels/interaction/commands/requirements/TokenManagerTag.java
+++ b/src/me/rockyhawk/commandpanels/interaction/commands/requirements/TokenManagerTag.java
@@ -1,0 +1,60 @@
+package me.rockyhawk.commandpanels.interaction.commands.requirements;
+
+import me.realized.tokenmanager.TokenManagerPlugin;
+import me.realized.tokenmanager.api.TokenManager;
+import me.rockyhawk.commandpanels.Context;
+import me.rockyhawk.commandpanels.formatter.language.Message;
+import me.rockyhawk.commandpanels.interaction.commands.RequirementTagResolver;
+import me.rockyhawk.commandpanels.session.Panel;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import java.util.OptionalLong;
+
+public class TokenManagerTag implements RequirementTagResolver {
+
+    private final TokenManager tokenManager;
+
+    public TokenManagerTag() {
+        if (Bukkit.getServer().getPluginManager().getPlugin("TokenManager") == null) {
+            this.tokenManager = null;
+            return;
+        }
+        this.tokenManager = TokenManagerPlugin.getInstance();
+    }
+
+    @Override
+    public boolean isCorrectTag(String tag) {
+        return tag.equalsIgnoreCase("[tokenmanager]");
+    }
+
+    @Override
+    public boolean check(Context ctx, Panel panel, Player player, String raw, String args) {
+        if (tokenManager == null) return false;
+
+        Long amount = parseAmount(ctx, player, args);
+        if (amount == null) return false;
+
+        OptionalLong tokens = tokenManager.getTokens(player);
+        return tokens.isPresent() && tokens.getAsLong() >= amount;
+    }
+
+    @Override
+    public void execute(Context ctx, Panel panel, Player player, String raw, String args) {
+        if (tokenManager == null) return;
+
+        Long amount = parseAmount(ctx, player, args);
+        if (amount == null) return;
+
+        tokenManager.removeTokens(player, amount);
+    }
+
+    private Long parseAmount(Context ctx, Player player, String args) {
+        try {
+            return Long.parseLong(args);
+        } catch (NumberFormatException e) {
+            ctx.text.sendError(player, Message.REQUIREMENT_ECONOMY_INVALID, args);
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
Add [tokenmanager] requirement tag for panels, allowing server owners to require and deduct tokens from players using TokenManager plugin.

- New TokenManagerTag resolver following the same pattern as VaultTag
- TokenManager declared as optional dependency in paper-plugin.yml
- Graceful degradation when TokenManager is not installed

The v3 version supported TokenManager, I know that this is abandoned plugin, but I have public fork that updated to new versions