### PR TITLE
customizable afterAction to prevent dialog window reset

### DIFF
--- a/src/me/rockyhawk/commandpanels/builder/dialog/DialogPanelBuilder.java
+++ b/src/me/rockyhawk/commandpanels/builder/dialog/DialogPanelBuilder.java
@@ -106,6 +106,9 @@ public class DialogPanelBuilder extends PanelBuilder {
             exitAction = null;
         }
 
+        // Getting the after action with fallback to "close" (paper / vanilla behavior)
+        final DialogBase.DialogAfterAction afterAction = DialogBase.DialogAfterAction.NAMES.valueOr(panel.getAfterAction(), DialogBase.DialogAfterAction.CLOSE);
+
         // Make sure there is at least one button
         if (buttons.isEmpty()) {
             ctx.text.sendError(player, Message.DIALOG_NO_BUTTONS);
@@ -120,6 +123,8 @@ public class DialogPanelBuilder extends PanelBuilder {
                         .canCloseWithEscape(Boolean.parseBoolean(
                                 ctx.text.parseTextToString(player, panel.getEscapable())))
                         .body(bodies)
+                        .pause(false) // pause must be disabled to allow setting non-default afterAction
+                        .afterAction(afterAction)
                         .inputs(inputs)
                         .build())
                 .type(DialogType.multiAction(

--- a/src/me/rockyhawk/commandpanels/session/dialog/DialogPanel.java
+++ b/src/me/rockyhawk/commandpanels/session/dialog/DialogPanel.java
@@ -21,6 +21,7 @@ public class DialogPanel extends Panel {
     private final String escapable;
     private final String exitButton;
     private final String floodgate;
+    private final String afterAction;
     private final Map<String, DialogComponent> components = new HashMap<>();
     private final Map<String, List<String>> order = new HashMap<>();
 
@@ -31,6 +32,7 @@ public class DialogPanel extends Panel {
         this.columns = config.getString("columns", "1");
         this.escapable = config.getString("escapable", "true");
         this.exitButton = config.getString("has-exit-button", "false");
+        this.afterAction = config.getString("after-action", "close");
 
         ConfigurationSection order = config.getConfigurationSection("layout");
         if (order != null) {
@@ -101,5 +103,9 @@ public class DialogPanel extends Panel {
 
     public String getExitButton() {
         return exitButton;
+    }
+
+    public String getAfterAction() {
+        return afterAction;
     }
 }


### PR DESCRIPTION
Setting `after-action` to `none` prevents closing current dialog on button click. Meaning, you can switch between dialogs without flickering and cursor position resets.